### PR TITLE
remove build-time variables and other minor tweaks

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -5,14 +5,9 @@ name: RPE AKS RBAC Enabled Pipeline
 trigger: none
 pr: none
 variables:
-  aksResourceGroup: ''
-  aksVnetCidr: ''
-  aksSubnetCidr: ''
-  aksServiceCidr: ''
-  aksDnsServiceIp: ''
   keyvaultName: rpe-infra
   serviceConnection: azurerm-rpetemp
-  helmVersion: '2.12.0'
+  helmVersion: '2.13.0'
   location: 'UK South'
   acrName: rpedev
   adminNamespace: 'admin'

--- a/templates/arm-aks-parameters.json
+++ b/templates/arm-aks-parameters.json
@@ -6,10 +6,10 @@
       "value": ""
     },
     "kubernetesVersion": {
-      "value": "1.12.5"
+      "value": "1.12.6"
     },
     "vmSize": {
-      "value": "Standard_B2ms"
+      "value": "Standard_B4ms"
     },
     "nodeCount": {
       "value": 2
@@ -18,7 +18,7 @@
       "value": ""
     },
     "dnsPrefix": {
-      "value": "cnp-aks-rpe-cluster--bf308a"
+      "value": "cnp-aks-rpe-cluster"
     },
     "sshPublicKey": {
       "value": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDByksOKZjMovSnLZGIljdrs6bSvUNM514q/HCo5ITi1P/pMbARYHFl62AyxSrIuk+0RA2dYlzl6H1iluQa2bPT5PQqii9cA1XDnCBikkrLO2lMDG11Pu0cvDdYZNCrfgcpWZLy987mwOWchnWDGOdvIHv8Drx8eywL7Mzrx0wXS+vBOozUq0bN3ze9+mH6igRO/05e+r2PC+ohL4g0998qShvOoETU16bzcSm1TAKs6kCUPCnjj1y2/8nXAcYUKyesqSYx9brYhGbEPgE51IY6KQG24t7NNers17jqqgDAjO6a6d4jxgmJInLb5fziuelysOAP7pU0l0i8f9dtQu6H"


### PR DESCRIPTION
If build-time variables are present in the YAML, they can't be overridden.  Used to work, but doesn't anymore.  It's in the docs as well: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#allow-at-queue-time