### PR TITLE
logic app fix - removed google api integration

### DIFF
--- a/templates/arm-mon-infra.json
+++ b/templates/arm-mon-infra.json
@@ -39,10 +39,9 @@
     "resources": [
         {
             "type": "Microsoft.Logic/workflows",
-            "name": "[parameters('logicAppName')]",
             "apiVersion": "2017-07-01",
+            "name": "[parameters('logicAppName')]",
             "location": "[resourceGroup().location]",
-            "scale": null,
             "properties": {
                 "state": "Enabled",
                 "definition": {
@@ -251,27 +250,9 @@
                             },
                             "else": {
                                 "actions": {
-                                    "HTTP_3": {
-                                        "runAfter": {
-                                            "Parse_JSON": [
-                                                "Succeeded"
-                                            ]
-                                        },
-                                        "type": "Http",
-                                        "inputs": {
-                                            "body": {
-                                                "longUrl": "@{body('Parse_JSON')?['LinkToSearchResults']}"
-                                            },
-                                            "headers": {
-                                                "Content-Type": "application/json"
-                                            },
-                                            "method": "POST",
-                                            "uri": "https://www.googleapis.com/urlshortener/v1/url?key=AIzaSyBkT1BRbA-uULHz8HMUAi0ywJtpNLXHShI"
-                                        }
-                                    },
                                     "HTTP_4": {
                                         "runAfter": {
-                                            "HTTP_3": [
+                                            "Parse_JSON": [
                                                 "Succeeded"
                                             ]
                                         },
@@ -294,7 +275,7 @@
                                                             }
                                                         ],
                                                         "text": "Description: _@{body('Parse_JSON')?['Description']}_",
-                                                        "title": "<@{body('HTTP_3')['id']}|Alert> - @{body('Parse_JSON')?['AlertRuleName']}"
+                                                        "title": "<@{body('Parse_JSON')?['LinkToSearchResults']}|Alert> - @{body('Parse_JSON')?['AlertRuleName']}"
                                                     }
                                                 ],
                                                 "channel": "[parameters('slackChannel')]",
@@ -434,8 +415,7 @@
                     "outputs": {}
                 },
                 "parameters": {}
-            },
-            "dependsOn": []
+            }
         },
         {
             "type": "Microsoft.Insights/actionGroups",


### PR DESCRIPTION
google api integration stopped working, it was replaced with link provided with alert payload