### PR TITLE
RPE-1105 - remove link to results

### DIFF
--- a/templates/arm-mon-infra.json
+++ b/templates/arm-mon-infra.json
@@ -275,7 +275,7 @@
                                                             }
                                                         ],
                                                         "text": "Description: _@{body('Parse_JSON')?['Description']}_",
-                                                        "title": "<@{body('Parse_JSON')?['LinkToSearchResults']}|Alert> - @{body('Parse_JSON')?['AlertRuleName']}"
+                                                        "title": "Alert - @{body('Parse_JSON')?['AlertRuleName']}"
                                                     }
                                                 ],
                                                 "channel": "[parameters('slackChannel')]",


### PR DESCRIPTION
remove link to results as it is to long and breaks slack message