### PR TITLE
2nd NeuVector file share

### DIFF
--- a/scripts/create-azure-file-share.sh
+++ b/scripts/create-azure-file-share.sh
@@ -7,10 +7,13 @@ VAULT_NAME=$3
 
 # Create an azure file share for NeuVector persistent storage
 CONNECTION_STRING=$(az storage account show-connection-string -n ${STORAGE_ACCOUNT_NAME} -g ${RESOURCE_GROUP_NAME} --query 'connectionString' -o tsv)
-az storage share create --name neuvector-data --quota 1 --connection-string ${CONNECTION_STRING}
+az storage share create --name neuvector-data-00 --quota 1 --connection-string ${CONNECTION_STRING}
+az storage share create --name neuvector-data-01 --quota 1 --connection-string ${CONNECTION_STRING}
+
+STORAGE_ACCOUNT_KEY=$(az storage account keys list --account-name ${STORAGE_ACCOUNT_NAME} --resource-group ${RESOURCE_GROUP_NAME} --query [0].value -o tsv)
 
 az keyvault secret set \
  --vault-name ${VAULT_NAME} \
- --name "sa-connection-string" \
- --value ${CONNECTION_STRING} \
- --description "Infra storage account connection string"
+ --name "storage-account-key" \
+ --value ${STORAGE_ACCOUNT_KEY} \
+ --description "Infra storage account key"


### PR DESCRIPTION
- add two file shares to support 2 clusters
- store storage account key instead of entire connection string