### PR TITLE
Enabling experimental feature for flux to test kustomize

### DIFF
--- a/deployments/weave-flux/values.yaml
+++ b/deployments/weave-flux/values.yaml
@@ -9,3 +9,5 @@ registry:
 git:
   url: git@github.com:hmcts/cnp-flux-config
   pollInterval: 1m
+additionalArgs:
+  - --manifest-generation=true


### PR DESCRIPTION

### Change description ###

Enabling experimental feature for flux to test kustomize. This doesn't break/change anything existing till it finds manifest files. It is safe to enable on other clusters as well.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
