### PR TITLE
Fixing disabling dashboard

### DIFF
--- a/scripts/remove-dashboard.sh
+++ b/scripts/remove-dashboard.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
-# disabled due to: https://github.com/Azure/AKS/issues/786
-#kubectl --namespace kube-system delete deployment kubernetes-dashboard
-#kubectl --namespace  kube-system delete svc kubernetes-dashboard
+CLUSTER_NAME=$1
+RESOURCE_GROUP_NAME=$2
+
+az aks disable-addons -a kube-dashboard --name ${CLUSTER_NAME} --resource-group ${RESOURCE_GROUP_NAME} --no-wait


### PR DESCRIPTION
Fixes [AB#304](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/304)

Tried on sbox with PR build and works :
https://dev.azure.com/hmcts/CNP/_releaseProgress?releaseId=1760&_a=release-environment-logs&environmentId=6191
```
Atrocitus:~ praveenakainos.com$ az aks browse --resource-group sbox-01-rg --name sbox-01-aks --subscription b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb
The kube-dashboard addon was disabled for this managed cluster.
To use "az aks browse" first enable the add-on
by running "az aks enable-addons --addons kube-dashboard".
Atrocitus:~ praveenakainos.com$ az aks browse --resource-group sbox-00-rg --name sbox-00-aks --subscription b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb
The kube-dashboard addon was disabled for this managed cluster.
To use "az aks browse" first enable the add-on
by running "az aks enable-addons --addons kube-dashboard".
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
