### PR TITLE
Adding sonobuoy to testing clusters

### DIFF
--- a/scripts/sonobuoy-test.sh
+++ b/scripts/sonobuoy-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+MODE=$1
+
+go get -u -v github.com/heptio/sonobuoy
+sonobuoy delete --wait
+
+sonobuoy run --mode ${MODE} --wait
+results=$(sonobuoy retrieve)
+sonobuoy e2e $results
+
+# unzipping results to publish as test artifacts
+mkdir results && tar -xf $results -C results
+
+
+sonobuoy delete --all
+


### PR DESCRIPTION
Adding sonobuoy to perform conformance tests , this will help us validate the cluster is all good after rolling out the change. See https://github.com/heptio/sonobuoy . Note that the K8s conformance tests run for more than an hour and E2E tests run for about 12 hours. So, this needs to be used sensibly. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
