### PR TITLE
Fixing service connection names as they are renamed now in azure devops

### DIFF
--- a/variablegroups/DEMO-AKS-Common.json
+++ b/variablegroups/DEMO-AKS-Common.json
@@ -46,7 +46,7 @@
       "value": "cftapps-demo"
     },
     "Subscription.ServiceConnection.Name": {
-      "value": "DCD-CFTAPPS-DEMO (aks-infra-demo)"
+      "value": "DCD-CFTAPPS-DEMO"
     },
     "Subscription.StorageAccount.Name": {
       "value": "cftapps$(Subscription.AKS.Environment.Name)"

--- a/variablegroups/MI-SBOX-AKS-Common.json
+++ b/variablegroups/MI-SBOX-AKS-Common.json
@@ -46,7 +46,7 @@
       "value": "mi-sbox"
     },
     "Subscription.ServiceConnection.Name": {
-      "value": "DCD-MI-SBOX (aks-infra-sbox)"
+      "value": "DCD-MI-SBOX"
     },
     "Subscription.StorageAccount.Name": {
       "value": "misbox"

--- a/variablegroups/PAPI-SBOX-AKS-Common.json
+++ b/variablegroups/PAPI-SBOX-AKS-Common.json
@@ -46,7 +46,7 @@
       "value": "papi-sbox"
     },
     "Subscription.ServiceConnection.Name": {
-      "value": "DCD-PAPI-SBOX (aks-infra-sbox)"
+      "value": "DCD-PAPI-SBOX"
     },
     "Subscription.StorageAccount.Name": {
       "value": "papisbox"

--- a/variablegroups/SBOX-AKS-Common.json
+++ b/variablegroups/SBOX-AKS-Common.json
@@ -46,7 +46,7 @@
       "value": "cftapps-sbox"
     },
     "Subscription.ServiceConnection.Name": {
-      "value": "DCD-CFTAPPS-SBOX (aks-infra-sbox)"
+      "value": "DCD-CFTAPPS-SBOX"
     },
     "Subscription.StorageAccount.Name": {
       "value": "cftapps$(Subscription.AKS.Environment.Name)"


### PR DESCRIPTION

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
