### PR TITLE
add private ip to keyvault

### DIFF
--- a/terraform/app-gateway-module/secret.tf
+++ b/terraform/app-gateway-module/secret.tf
@@ -1,0 +1,12 @@
+data "azurerm_key_vault" "main" {
+  name                = "cftapps-${var.subscription}"
+  resource_group_name = "core-infra-${var.subscription}-rg"
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  name         = "internal-lb-ip"
+  value        = "${var.private_ip_address}"
+  key_vault_id = "${data.azurerm_key_vault.main.id}"
+
+  tags = local.tags
+}

--- a/terraform/app-gateway-module/variables.tf
+++ b/terraform/app-gateway-module/variables.tf
@@ -6,6 +6,10 @@ variable "env" {
   description = "environment, will be used in resource names and for looking up the vnet details"
 }
 
+variable "subscription" {
+  description = "subscription, will be used for looking up the keyvault details"
+}
+
 variable "location" {
   description = "location to deploy resources to"
 }

--- a/terraform/ithc.tfvars
+++ b/terraform/ithc.tfvars
@@ -1,2 +1,3 @@
+subscription              = "ithc"
 env                       = "ithc"
 app_gw_private_ip_address = "10.10.36.121"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,6 +16,9 @@ terraform {
 
 variable "env" {}
 variable "app_gw_private_ip_address" {}
+variable "subscription" {
+  description = "subscription, will be used for looking up the keyvault details"
+}
 
 module "app-gw" {
   source    = "./app-gateway-module"
@@ -24,4 +27,5 @@ module "app-gw" {
 
   location           = var.location
   private_ip_address = var.app_gw_private_ip_address
+  subscription       = var.subscription
 }

--- a/terraform/sbox.tfvars
+++ b/terraform/sbox.tfvars
@@ -1,2 +1,3 @@
 env                       = "sbox"
 app_gw_private_ip_address = "10.10.7.122"
+subscription              = "sbox"

--- a/terraform/stg.tfvars
+++ b/terraform/stg.tfvars
@@ -1,2 +1,3 @@
 env                       = "aat"
 app_gw_private_ip_address = "10.10.24.121"
+subscription              = "stg"

--- a/terraform/test.tfvars
+++ b/terraform/test.tfvars
@@ -1,2 +1,3 @@
 env                       = "perftest"
 app_gw_private_ip_address = "10.10.46.121"
+subscription              = "test"


### PR DESCRIPTION
Not sure how are we adding the secret to the keyvault. I couldn't find any so added the snippet to add the secret within the app gateway module. As it makes sense to add the secret right in the module when the gateway is created.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
