### PR TITLE
Bumping AKS version

### DIFF
--- a/templates/arm-aks-template.json
+++ b/templates/arm-aks-template.json
@@ -7,7 +7,7 @@
     },
     "kubernetesVersion": {
       "type": "string",
-      "defaultValue": "1.13.9"
+      "defaultValue": "1.13.10"
     },
     "vmSize": {
       "type": "string",

--- a/templates/arm-aks-template.json
+++ b/templates/arm-aks-template.json
@@ -7,7 +7,7 @@
     },
     "kubernetesVersion": {
       "type": "string",
-      "defaultValue": "1.13.7"
+      "defaultValue": "1.13.9"
     },
     "vmSize": {
       "type": "string",

--- a/variablegroups/AAT-AKS-Common.json
+++ b/variablegroups/AAT-AKS-Common.json
@@ -25,7 +25,7 @@
       "value": "10.10.25.0/24"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.9"
+      "value": "1.13.10"
     },
     "Subscription.AKS.nodeCount": {
       "value": "4"

--- a/variablegroups/AAT-AKS-Common.json
+++ b/variablegroups/AAT-AKS-Common.json
@@ -25,7 +25,7 @@
       "value": "10.10.25.0/24"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.7"
+      "value": "1.13.9"
     },
     "Subscription.AKS.nodeCount": {
       "value": "4"

--- a/variablegroups/DEMO-AKS-Common.json
+++ b/variablegroups/DEMO-AKS-Common.json
@@ -19,7 +19,7 @@
       "value": "true"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.9"
+      "value": "1.13.10"
     },
     "Subscription.AKS.nodeCount": {
       "value": "4"

--- a/variablegroups/DEMO-AKS-Common.json
+++ b/variablegroups/DEMO-AKS-Common.json
@@ -19,7 +19,7 @@
       "value": "true"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.7"
+      "value": "1.13.9"
     },
     "Subscription.AKS.nodeCount": {
       "value": "4"

--- a/variablegroups/ITHC-AKS-Common.json
+++ b/variablegroups/ITHC-AKS-Common.json
@@ -19,7 +19,7 @@
       "value": "true"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.7"
+      "value": "1.13.9"
     },
     "Subscription.AKS.nodeCount": {
       "value": "3"

--- a/variablegroups/ITHC-AKS-Common.json
+++ b/variablegroups/ITHC-AKS-Common.json
@@ -19,7 +19,7 @@
       "value": "true"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.9"
+      "value": "1.13.10"
     },
     "Subscription.AKS.nodeCount": {
       "value": "3"

--- a/variablegroups/MGMT-SBOX-AKS-Common.json
+++ b/variablegroups/MGMT-SBOX-AKS-Common.json
@@ -19,7 +19,7 @@
       "value": "false"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.9"
+      "value": "1.13.10"
     },
     "Subscription.AKS.nodeCount": {
       "value": "3"

--- a/variablegroups/MGMT-SBOX-AKS-Common.json
+++ b/variablegroups/MGMT-SBOX-AKS-Common.json
@@ -19,7 +19,7 @@
       "value": "false"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.7"
+      "value": "1.13.9"
     },
     "Subscription.AKS.nodeCount": {
       "value": "3"

--- a/variablegroups/MI-SBOX-AKS-Common.json
+++ b/variablegroups/MI-SBOX-AKS-Common.json
@@ -19,7 +19,7 @@
       "value": "false"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.9"
+      "value": "1.13.10"
     },
     "Subscription.AKS.nodeCount": {
       "value": "2"

--- a/variablegroups/MI-SBOX-AKS-Common.json
+++ b/variablegroups/MI-SBOX-AKS-Common.json
@@ -19,7 +19,7 @@
       "value": "false"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.7"
+      "value": "1.13.9"
     },
     "Subscription.AKS.nodeCount": {
       "value": "2"

--- a/variablegroups/PAPI-SBOX-AKS-Common.json
+++ b/variablegroups/PAPI-SBOX-AKS-Common.json
@@ -19,7 +19,7 @@
       "value": "true"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.9"
+      "value": "1.13.10"
     },
     "Subscription.AKS.nodeCount": {
       "value": "2"

--- a/variablegroups/PERFTEST-AKS-Common.json
+++ b/variablegroups/PERFTEST-AKS-Common.json
@@ -25,7 +25,7 @@
       "value": "10.10.47.0/24"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.7"
+      "value": "1.13.9"
     },
     "Subscription.AKS.nodeCount": {
       "value": "3"

--- a/variablegroups/PERFTEST-AKS-Common.json
+++ b/variablegroups/PERFTEST-AKS-Common.json
@@ -25,7 +25,7 @@
       "value": "10.10.47.0/24"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.9"
+      "value": "1.13.10"
     },
     "Subscription.AKS.nodeCount": {
       "value": "3"

--- a/variablegroups/RPE-AKS-Common.json
+++ b/variablegroups/RPE-AKS-Common.json
@@ -22,7 +22,7 @@
       "value": "10.10.4.0/24"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.7"
+      "value": "1.13.9"
     },
     "Subscription.AKS.nodeCount": {
       "value": "3"

--- a/variablegroups/RPE-AKS-Common.json
+++ b/variablegroups/RPE-AKS-Common.json
@@ -22,7 +22,7 @@
       "value": "10.10.4.0/24"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.9"
+      "value": "1.13.10"
     },
     "Subscription.AKS.nodeCount": {
       "value": "3"

--- a/variablegroups/SBOX-AKS-Common.json
+++ b/variablegroups/SBOX-AKS-Common.json
@@ -19,7 +19,7 @@
       "value": "false"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.9"
+      "value": "1.13.10"
     },
     "Subscription.AKS.nodeCount": {
       "value": "2"

--- a/variablegroups/SBOX-AKS-Common.json
+++ b/variablegroups/SBOX-AKS-Common.json
@@ -19,7 +19,7 @@
       "value": "false"
     },
     "Subscription.AKS.Kubernetes.version": {
-      "value": "1.13.7"
+      "value": "1.13.9"
     },
     "Subscription.AKS.nodeCount": {
       "value": "2"


### PR DESCRIPTION
1.13.7 version is no more supported.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
