### PR TITLE
Add evidence management team products

### DIFF
--- a/team-config/prod/all.yaml
+++ b/team-config/prod/all.yaml
@@ -38,6 +38,20 @@ gateways:
         component: cms
       - product: div
         component: cos
+
+    # Evidence Management
+      - product: em
+        component: anno
+      - product: em
+        component: npa
+      - product: em
+        component: stitching
+      - product: em
+        component: ccd-orchestrator
+      - product: dg
+        component: docassembly
+      - product: dm
+        component: dm-store 
  
     # SSCS
       - product: sscs

--- a/team-config/prod/all.yaml
+++ b/team-config/prod/all.yaml
@@ -51,7 +51,7 @@ gateways:
       - product: dg
         component: docassembly
       - product: dm
-        component: dm-store 
+        component: store 
  
     # SSCS
       - product: sscs


### PR DESCRIPTION
Add the Evidence Management team products. Note that the dm product hasn't been created yet.