### PR TITLE
Truncate action group short name

### DIFF
--- a/templates/arm-mon-infra.json
+++ b/templates/arm-mon-infra.json
@@ -59,7 +59,7 @@
     "variables" : {
         "agName" : "[concat('aks_',parameters('environmentName'),'_action_group')]",
         "defaultAgShortName" : "[concat('aks',parameters('environmentName'))]",
-        "agShortName": "[if(greater(length(variables('defaultAgShortName'), 12), substring(variables('defaultAgShortName'), 0, 11), variables('defaultAgShortName'))]",
+        "agShortName": "[take(variables('defaultAgShortName'), 12)]",
         "logicAppName": "[concat('aks-',parameters('environmentName'),'-monitoring-la')]"
     },
     "resources": [

--- a/templates/arm-mon-infra.json
+++ b/templates/arm-mon-infra.json
@@ -58,7 +58,8 @@
     },
     "variables" : {
         "agName" : "[concat('aks_',parameters('environmentName'),'_action_group')]",
-        "agShortName" : "[concat('aks',parameters('environmentName'))]",
+        "defaultAgShortName" : "[concat('aks',parameters('environmentName'))]",
+        "agShortName": "[if(greater(length(variables('defaultAgShortName'), 12), substring(variables('defaultAgShortName'), 0, 11), variables('defaultAgShortName'))]",
         "logicAppName": "[concat('aks-',parameters('environmentName'),'-monitoring-la')]"
     },
     "resources": [


### PR DESCRIPTION
### JIRA link (if applicable) ###
[AB#608](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/608)


### Change description ###
Limit to 12 characters for action group short name, because of the naming conventions we've ended up with an env called cftsbox-intsvc, which is too long.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
