### PR TITLE
Increased AKS Node OS Disk Size

### DIFF
--- a/templates/arm-aks-template.json
+++ b/templates/arm-aks-template.json
@@ -112,7 +112,7 @@
     }
   },
   "variables": {
-    "osDiskSizeGB": 256,
+    "osDiskSizeGB": 1024,
     "maxPods": 30,  
     "nodepoolName" : "nodepool",
     "storageProfile": "ManagedDisks",

--- a/templates/arm-aks-template.json
+++ b/templates/arm-aks-template.json
@@ -112,7 +112,7 @@
     }
   },
   "variables": {
-    "osDiskSizeGB": 100,
+    "osDiskSizeGB": 256,
     "maxPods": 30,  
     "nodepoolName" : "nodepool",
     "storageProfile": "ManagedDisks",


### PR DESCRIPTION
### JIRA link (if applicable) ###

[AB#697](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/697)

### Change description ###

Increased the OS Disk Size for AKS Nodes. We believe that the current disk provisioned is the reason for DNS failures. According to the issue opened by MSFT below, Node OS Disk Saturation can have an impact on dns resolution. Increasing the disk size prompts Azure to spin up a disk with higher IOPS than the default one. 

https://github.com/Azure/AKS/issues/1373

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
