### PR TITLE
Updated DNS entries for MGMT clusters

### DIFF
--- a/variablegroups/CFTPTL-AKS-Common.json
+++ b/variablegroups/CFTPTL-AKS-Common.json
@@ -37,7 +37,7 @@
       "value": "10.10.64.0/21"
     },
     "Subscription.AKS.VNet.DnsServers": {
-      "value": "[\"172.16.0.10\", \"172.16.0.14\"]"
+      "value": "10.96.4.12"
     },
     "Subscription.keyvaultName": {
       "value": "cftptl-intsvc"

--- a/variablegroups/MGMT-SBOX-AKS-Common.json
+++ b/variablegroups/MGMT-SBOX-AKS-Common.json
@@ -37,7 +37,7 @@
       "value": "10.10.8.0/21"
     },
     "Subscription.AKS.VNet.DnsServers": {
-      "value": "[\"172.16.0.10\", \"172.16.0.14\"]"
+      "value": "10.99.196.9"
     },
     "Subscription.keyvaultName": {
       "value": "cftsbox-intsvc"


### PR DESCRIPTION
### JIRA link (if applicable) ###

[AB#697](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/697)

### Change description ###

Updated MGMT clusters to use the DNS servers currently residing on the old Jenkins servers.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
