### PR TITLE
Scale up aat

### DIFF
--- a/templates/vars/aks/aat.json
+++ b/templates/vars/aks/aat.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "nodeMinCount": {
-      "value": "16"
+      "value": "22"
     },
     "nodeMaxCount": {
       "value": "30"


### PR DESCRIPTION
It is running 18 currently, which isn't enough for idam pods.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
