### PR TITLE
Add routing tables to AKS to allow route back to bastion network

### DIFF
--- a/templates/arm-vnet-template.json
+++ b/templates/arm-vnet-template.json
@@ -118,11 +118,24 @@
     "serviceEndpoints": {
       "type": "array",
       "defaultValue": []
+    },
+    "bastionSubnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The address prefix of the bastion subnet"
+      }
+    },
+    "bastionSubnetNextHop": {
+      "type": "string",
+      "metadata": {
+        "description": "The next hop to reach the bastion vnet (Hub network; Palo Alto Load Balancer)"
+      }
     }
   },
   "variables": {
     "primarySubnetName": "[concat('aks-',parameters('aksPrimarySubnetName'))]",
     "secondarySubnetName": "[concat('aks-',parameters('aksSecondarySubnetName'))]",
+    "routeTableName": "aks-route-table",
     "nsgRulesMapping": {
       "true": "[parameters('aksNetworkSecurityGroupsSettings').securityRules]",
       "false": [{
@@ -294,6 +307,36 @@
       ]
     },
     {
+      "type": "Microsoft.Network/routeTables",
+      "name": "[variables('routeTableName')]",
+      "apiVersion": "2020-05-01",
+      "location": "[resourceGroup().location]",
+      "tags" : {
+        "EnvironmentName": "[parameters('environmentName')]",
+        "Branch":"[parameters('branch')]",
+        "managedBy":"[parameters('managedBy')]",
+        "solutionOwner": "[parameters('solutionOwner')]",
+        "activityName": "[parameters('activityName')]",
+        "dataClassification":"[parameters('dataClassification')]",
+        "automation": "[parameters('automation')]",
+        "costCentre":"[parameters('costCentre')]",
+        "environment": "[parameters('environment')]",
+        "criticality": "[parameters('criticality')]"
+      },
+      "properties": {
+        "routes": [
+          {
+            "name": "BastionMgmtVnet",
+            "properties": {
+              "addressPrefix": "[parameters('bastionSubnetPrefix')]",
+              "nextHopType": "VirtualAppliance",
+              "nextHopIpAddress": "[parameters('bastionSubnetNextHop')]"
+            }
+          }
+        ]
+      }
+    },
+    {
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('aksVnetName')]",
       "apiVersion": "2019-04-01",
@@ -328,6 +371,9 @@
               "serviceEndpoints": "[parameters('serviceEndpoints')]",
               "networkSecurityGroup": {
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('aksNsgName'))]"
+              },
+              "routeTable": {
+                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
               }
             }
           },
@@ -338,6 +384,9 @@
               "serviceEndpoints": "[parameters('serviceEndpoints')]",
               "networkSecurityGroup": {
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('aksNsgName'))]"
+              },
+              "routeTable": {
+                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
               }
             }
           },
@@ -358,6 +407,9 @@
               "serviceEndpoints": "[parameters('serviceEndpoints')]",
               "networkSecurityGroup": {
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('iaasNsgName'))]"
+              },
+              "routeTable": {
+                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
               }
             }
           }
@@ -421,7 +473,8 @@
       "dependsOn": [
         "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('aksNsgName'))]",
         "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('appgwNsgName'))]",
-        "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('iaasNsgName'))]"
+        "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('iaasNsgName'))]",
+        "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
       ]
     },
     {

--- a/templates/vars/aks/perftest.json
+++ b/templates/vars/aks/perftest.json
@@ -6,7 +6,7 @@
       "value": "1.17.7"
     },
     "nodeCount": {
-      "value": 14
+      "value": 16
     },
     "nodeMinCount": {
       "value": ""

--- a/templates/vars/vnet/aat.json
+++ b/templates/vars/vnet/aat.json
@@ -61,6 +61,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.0"
+    },
+    "bastionSubnetNextHop": {
+      "value": "10.11.8.36"
     }
   }
 }

--- a/templates/vars/vnet/aat.json
+++ b/templates/vars/vnet/aat.json
@@ -63,7 +63,7 @@
       ]
     },
     "bastionSubnetPrefix": {
-      "value": "10.48.0.0"
+      "value": "10.48.0.0/27"
     },
     "bastionSubnetNextHop": {
       "value": "10.11.8.36"

--- a/templates/vars/vnet/demo.json
+++ b/templates/vars/vnet/demo.json
@@ -48,7 +48,7 @@
       ]
     },
     "bastionSubnetPrefix": {
-      "value": "10.48.0.32"
+      "value": "10.48.0.32/27"
     },
     "bastionSubnetNextHop": {
       "value": "10.11.72.36"

--- a/templates/vars/vnet/demo.json
+++ b/templates/vars/vnet/demo.json
@@ -46,6 +46,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.32"
+    },
+    "bastionSubnetNextHop": {
+      "value": "10.11.72.36"
     }
   }
 }

--- a/templates/vars/vnet/ithc.json
+++ b/templates/vars/vnet/ithc.json
@@ -48,7 +48,7 @@
       ]
     },
     "bastionSubnetPrefix": {
-      "value": "10.48.0.0"
+      "value": "10.48.0.0/27"
     },
     "bastionSubnetNextHop": {
       "value": "10.11.8.36"

--- a/templates/vars/vnet/ithc.json
+++ b/templates/vars/vnet/ithc.json
@@ -46,6 +46,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.0"
+    },
+    "bastionSubnetNextHop": {
+      "value": "10.11.8.36"
     }
   }
 }

--- a/templates/vars/vnet/perftest.json
+++ b/templates/vars/vnet/perftest.json
@@ -48,7 +48,7 @@
       ]
     },
     "bastionSubnetPrefix": {
-      "value": "10.48.0.32"
+      "value": "10.48.0.32/27"
     },
     "bastionSubnetNextHop": {
       "value": "10.11.72.36"

--- a/templates/vars/vnet/perftest.json
+++ b/templates/vars/vnet/perftest.json
@@ -46,6 +46,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.32"
+    },
+    "bastionSubnetNextHop": {
+      "value": "10.11.72.36"
     }
   }
 }

--- a/templates/vars/vnet/preview.json
+++ b/templates/vars/vnet/preview.json
@@ -68,7 +68,7 @@
       ]
     },
     "bastionSubnetPrefix": {
-      "value": "10.48.0.32"
+      "value": "10.48.0.32/27"
     },
     "bastionSubnetNextHop": {
       "value": "10.11.72.36"

--- a/templates/vars/vnet/preview.json
+++ b/templates/vars/vnet/preview.json
@@ -66,6 +66,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.32"
+    },
+    "bastionSubnetNextHop": {
+      "value": "10.11.72.36"
     }
   }
 }

--- a/templates/vars/vnet/prod.json
+++ b/templates/vars/vnet/prod.json
@@ -48,7 +48,7 @@
       ]
     },
     "bastionSubnetPrefix": {
-      "value": "10.48.0.0"
+      "value": "10.48.0.0/27"
     },
     "bastionSubnetNextHop": {
       "value": "10.11.8.36"

--- a/templates/vars/vnet/prod.json
+++ b/templates/vars/vnet/prod.json
@@ -46,6 +46,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.0"
+    },
+    "bastionSubnetNextHop": {
+      "value": "10.11.8.36"
     }
   }
 }

--- a/templates/vars/vnet/sbox.json
+++ b/templates/vars/vnet/sbox.json
@@ -58,7 +58,7 @@
       ]
     },
     "bastionSubnetPrefix": {
-      "value": "10.48.0.100"
+      "value": "10.48.0.100/27"
     },
     "bastionSubnetNextHop": {
       "value": "10.10.200.36"

--- a/templates/vars/vnet/sbox.json
+++ b/templates/vars/vnet/sbox.json
@@ -56,6 +56,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.100"
+    },
+    "bastionSubnetNextHop": {
+      "value": "10.10.200.36"
     }
   }
 }

--- a/templates/vars/vnet/sbox.json
+++ b/templates/vars/vnet/sbox.json
@@ -58,7 +58,7 @@
       ]
     },
     "bastionSubnetPrefix": {
-      "value": "10.48.0.100/27"
+      "value": "10.48.0.96/27"
     },
     "bastionSubnetNextHop": {
       "value": "10.10.200.36"

--- a/variablegroups/AAT-AKS-Common.json
+++ b/variablegroups/AAT-AKS-Common.json
@@ -55,7 +55,7 @@
       "value": "#aks-monitor-aat"
     },
     "Subscription.AKS.NSG.Settings": {
-      "value": "{ \"securityRules\": [] }"
+      "value": "{ \"securityRules\": [ {\"name\":\"BastionMgmtVnet\",\"description\":\"Permit access from Bastion network\",\"direction\":\"Inbound\",\"priority\":1000,\"sourceAddressPrefix\":\"10.48.0.0/27\",\"destinationAddressPrefix\":\"VirtualNetwork\",\"sourcePortRange\":\"*\",\"destinationPortRange\":\"*\",\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[],\"sourcePortRanges\":[]} ] }"
     },
     "Dynatrace.KeyVault.Name":{
       "value": "cftptl-intsvc"

--- a/variablegroups/AAT-AKS-Common.json
+++ b/variablegroups/AAT-AKS-Common.json
@@ -62,6 +62,12 @@
     },
     "Dynatrace.Instance.Name":{
       "value": "yrk32651"
+    },
+    "bastionSubnetPrefix": {
+      "values": "10.48.0.0"
+    },
+    "bastionSubnetNextHop": {
+      "value": "10.11.8.36"
     }
   },
   "id": 63,

--- a/variablegroups/AAT-AKS-Common.json
+++ b/variablegroups/AAT-AKS-Common.json
@@ -62,12 +62,6 @@
     },
     "Dynatrace.Instance.Name":{
       "value": "yrk32651"
-    },
-    "bastionSubnetPrefix": {
-      "values": "10.48.0.0"
-    },
-    "bastionSubnetNextHop": {
-      "value": "10.11.8.36"
     }
   },
   "id": 63,

--- a/variablegroups/DEMO-AKS-Common.json
+++ b/variablegroups/DEMO-AKS-Common.json
@@ -53,6 +53,12 @@
     },
     "Subscription.AKS.NSG.Settings": {
       "value": "{\"securityRules\":[{\"name\":\"AllowInternetToOAuthProxy\",\"description\":\"Allow Internet To OAuthProxy\",\"direction\":\"Inbound\",\"priority\":100,\"sourceAddressPrefix\":\"*\",\"destinationAddressPrefix\":\"51.11.25.221\",\"sourcePortRange\":\"*\",\"sourcePortRanges\":[],\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[\"80\",\"443\"],\"destinationPortRange\":null},{\"name\":\"TraefikNoProxy\",\"description\":\"Allow Internet To TraefikNoProxy\",\"direction\":\"Inbound\",\"priority\":110,\"sourceAddressPrefix\":\"*\",\"destinationAddressPrefix\":\"51.11.5.163\",\"sourcePortRange\":\"*\",\"destinationPortRange\":\"443\",\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[],\"sourcePortRanges\":[]},{\"name\":\"BulkscanToCrimeStorage\",\"description\":\"Permit access from bulkscan microservice to Crime storage endpoint located in a remote vpn network\",\"direction\":\"Outbound\",\"priority\":100,\"sourceAddressPrefix\":\"VirtualNetwork\",\"destinationAddressPrefix\":\"10.200.66.12\",\"sourcePortRange\":\"*\",\"destinationPortRange\":\"443\",\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[],\"sourcePortRanges\":[]}]}"
+    },
+    "bastionSubnetPrefix": {
+      "values": "10.48.0.32"
+    },
+    "bastionSubnetNextHop": {
+      "value": "10.11.72.36"
     }
   },
   "id": 22,

--- a/variablegroups/DEMO-AKS-Common.json
+++ b/variablegroups/DEMO-AKS-Common.json
@@ -52,7 +52,7 @@
       "value": "#aks-monitor-demo"
     },
     "Subscription.AKS.NSG.Settings": {
-      "value": "{\"securityRules\":[{\"name\":\"AllowInternetToOAuthProxy\",\"description\":\"Allow Internet To OAuthProxy\",\"direction\":\"Inbound\",\"priority\":100,\"sourceAddressPrefix\":\"*\",\"destinationAddressPrefix\":\"51.11.25.221\",\"sourcePortRange\":\"*\",\"sourcePortRanges\":[],\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[\"80\",\"443\"],\"destinationPortRange\":null},{\"name\":\"TraefikNoProxy\",\"description\":\"Allow Internet To TraefikNoProxy\",\"direction\":\"Inbound\",\"priority\":110,\"sourceAddressPrefix\":\"*\",\"destinationAddressPrefix\":\"51.11.5.163\",\"sourcePortRange\":\"*\",\"destinationPortRange\":\"443\",\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[],\"sourcePortRanges\":[]},{\"name\":\"BulkscanToCrimeStorage\",\"description\":\"Permit access from bulkscan microservice to Crime storage endpoint located in a remote vpn network\",\"direction\":\"Outbound\",\"priority\":100,\"sourceAddressPrefix\":\"VirtualNetwork\",\"destinationAddressPrefix\":\"10.200.66.12\",\"sourcePortRange\":\"*\",\"destinationPortRange\":\"443\",\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[],\"sourcePortRanges\":[]}]}"
+      "value": "{\"securityRules\":[ {\"name\":\"BastionMgmtVnet\",\"description\":\"Permit access from Bastion network\",\"direction\":\"Inbound\",\"priority\":1000,\"sourceAddressPrefix\":\"10.48.0.32/27\",\"destinationAddressPrefix\":\"VirtualNetwork\",\"sourcePortRange\":\"*\",\"destinationPortRange\":\"*\",\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[],\"sourcePortRanges\":[]} ] }"
     }
   },
   "id": 22,

--- a/variablegroups/DEMO-AKS-Common.json
+++ b/variablegroups/DEMO-AKS-Common.json
@@ -53,12 +53,6 @@
     },
     "Subscription.AKS.NSG.Settings": {
       "value": "{\"securityRules\":[{\"name\":\"AllowInternetToOAuthProxy\",\"description\":\"Allow Internet To OAuthProxy\",\"direction\":\"Inbound\",\"priority\":100,\"sourceAddressPrefix\":\"*\",\"destinationAddressPrefix\":\"51.11.25.221\",\"sourcePortRange\":\"*\",\"sourcePortRanges\":[],\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[\"80\",\"443\"],\"destinationPortRange\":null},{\"name\":\"TraefikNoProxy\",\"description\":\"Allow Internet To TraefikNoProxy\",\"direction\":\"Inbound\",\"priority\":110,\"sourceAddressPrefix\":\"*\",\"destinationAddressPrefix\":\"51.11.5.163\",\"sourcePortRange\":\"*\",\"destinationPortRange\":\"443\",\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[],\"sourcePortRanges\":[]},{\"name\":\"BulkscanToCrimeStorage\",\"description\":\"Permit access from bulkscan microservice to Crime storage endpoint located in a remote vpn network\",\"direction\":\"Outbound\",\"priority\":100,\"sourceAddressPrefix\":\"VirtualNetwork\",\"destinationAddressPrefix\":\"10.200.66.12\",\"sourcePortRange\":\"*\",\"destinationPortRange\":\"443\",\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[],\"sourcePortRanges\":[]}]}"
-    },
-    "bastionSubnetPrefix": {
-      "values": "10.48.0.32"
-    },
-    "bastionSubnetNextHop": {
-      "value": "10.11.72.36"
     }
   },
   "id": 22,

--- a/variablegroups/DEV-AKS-Common.json
+++ b/variablegroups/DEV-AKS-Common.json
@@ -55,7 +55,7 @@
       "value": "#aks-monitor-preview"
     },
     "Subscription.AKS.NSG.Settings": {
-      "value": "{ \"securityRules\": [] }"
+      "value": "{ \"securityRules\": [ {\"name\":\"BastionMgmtVnet\",\"description\":\"Permit access from Bastion network\",\"direction\":\"Inbound\",\"priority\":1000,\"sourceAddressPrefix\":\"10.48.0.32/27\",\"destinationAddressPrefix\":\"VirtualNetwork\",\"sourcePortRange\":\"*\",\"destinationPortRange\":\"*\",\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[],\"sourcePortRanges\":[]} ] }"
     }
   },
   "id": 25,

--- a/variablegroups/DEV-AKS-Common.json
+++ b/variablegroups/DEV-AKS-Common.json
@@ -56,6 +56,12 @@
     },
     "Subscription.AKS.NSG.Settings": {
       "value": "{ \"securityRules\": [] }"
+    },
+    "bastionSubnetPrefix": {
+      "values": "10.48.0.32"
+    },
+    "bastionSubnetNextHop": {
+      "value": "10.11.72.36"
     }
   },
   "id": 25,

--- a/variablegroups/DEV-AKS-Common.json
+++ b/variablegroups/DEV-AKS-Common.json
@@ -56,12 +56,6 @@
     },
     "Subscription.AKS.NSG.Settings": {
       "value": "{ \"securityRules\": [] }"
-    },
-    "bastionSubnetPrefix": {
-      "values": "10.48.0.32"
-    },
-    "bastionSubnetNextHop": {
-      "value": "10.11.72.36"
     }
   },
   "id": 25,

--- a/variablegroups/ITHC-AKS-Common.json
+++ b/variablegroups/ITHC-AKS-Common.json
@@ -52,7 +52,7 @@
       "value": "#aks-monitor-ithc"
     },
     "Subscription.AKS.NSG.Settings": {
-      "value": "{ \"securityRules\": [] }"
+      "value": "{ \"securityRules\": [ {\"name\":\"BastionMgmtVnet\",\"description\":\"Permit access from Bastion network\",\"direction\":\"Inbound\",\"priority\":1000,\"sourceAddressPrefix\":\"10.48.0.0/27\",\"destinationAddressPrefix\":\"VirtualNetwork\",\"sourcePortRange\":\"*\",\"destinationPortRange\":\"*\",\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[],\"sourcePortRanges\":[]} ] }"
     }
   },
   "id": 29,

--- a/variablegroups/ITHC-AKS-Common.json
+++ b/variablegroups/ITHC-AKS-Common.json
@@ -53,6 +53,12 @@
     },
     "Subscription.AKS.NSG.Settings": {
       "value": "{ \"securityRules\": [] }"
+    },
+    "bastionSubnetPrefix": {
+      "values": "10.48.0.0"
+    },
+    "bastionSubnetNextHop": {
+      "value": "10.11.8.36"
     }
   },
   "id": 29,

--- a/variablegroups/ITHC-AKS-Common.json
+++ b/variablegroups/ITHC-AKS-Common.json
@@ -53,12 +53,6 @@
     },
     "Subscription.AKS.NSG.Settings": {
       "value": "{ \"securityRules\": [] }"
-    },
-    "bastionSubnetPrefix": {
-      "values": "10.48.0.0"
-    },
-    "bastionSubnetNextHop": {
-      "value": "10.11.8.36"
     }
   },
   "id": 29,

--- a/variablegroups/PERFTEST-AKS-Common.json
+++ b/variablegroups/PERFTEST-AKS-Common.json
@@ -62,6 +62,12 @@
     },
     "Dynatrace.Instance.Name":{
       "value": "yrk32651"
+    },
+    "bastionSubnetPrefix": {
+      "values": "10.48.0.32"
+    },
+    "bastionSubnetNextHop": {
+      "value": "10.11.72.36"
     }
   },
   "id": 63,

--- a/variablegroups/PERFTEST-AKS-Common.json
+++ b/variablegroups/PERFTEST-AKS-Common.json
@@ -62,12 +62,6 @@
     },
     "Dynatrace.Instance.Name":{
       "value": "yrk32651"
-    },
-    "bastionSubnetPrefix": {
-      "values": "10.48.0.32"
-    },
-    "bastionSubnetNextHop": {
-      "value": "10.11.72.36"
     }
   },
   "id": 63,

--- a/variablegroups/PERFTEST-AKS-Common.json
+++ b/variablegroups/PERFTEST-AKS-Common.json
@@ -55,7 +55,7 @@
       "value": "#aks-monitor-test"
     },
     "Subscription.AKS.NSG.Settings": {
-      "value": "{ \"securityRules\": [] }"
+      "value": "{ \"securityRules\": [ {\"name\":\"BastionMgmtVnet\",\"description\":\"Permit access from Bastion network\",\"direction\":\"Inbound\",\"priority\":1000,\"sourceAddressPrefix\":\"10.48.0.32/27\",\"destinationAddressPrefix\":\"VirtualNetwork\",\"sourcePortRange\":\"*\",\"destinationPortRange\":\"*\",\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[],\"sourcePortRanges\":[]} ] }"
     },
     "Dynatrace.KeyVault.Name":{
       "value": "cftptl-intsvc"

--- a/variablegroups/Prod-AKS-Common.json
+++ b/variablegroups/Prod-AKS-Common.json
@@ -59,6 +59,12 @@
     },
     "Dynatrace.Instance.Name":{
       "value": "ebe20728"
+    },
+    "bastionSubnetPrefix": {
+      "values": "10.48.0.0"
+    },
+    "bastionSubnetNextHop": {
+      "value": "10.11.8.36"
     }
   },
   "id": 66,

--- a/variablegroups/Prod-AKS-Common.json
+++ b/variablegroups/Prod-AKS-Common.json
@@ -59,12 +59,6 @@
     },
     "Dynatrace.Instance.Name":{
       "value": "ebe20728"
-    },
-    "bastionSubnetPrefix": {
-      "values": "10.48.0.0"
-    },
-    "bastionSubnetNextHop": {
-      "value": "10.11.8.36"
     }
   },
   "id": 66,

--- a/variablegroups/Prod-AKS-Common.json
+++ b/variablegroups/Prod-AKS-Common.json
@@ -52,7 +52,7 @@
       "value": "#aks-monitor-prod"
     },
     "Subscription.AKS.NSG.Settings": {
-      "value": "{ \"securityRules\": [{\"name\":\"BulkscanToCrimeStorage\",\"description\":\"Permit access from bulkscan microservice to Crime storage endpoint located in a remote vpn network\",\"direction\":\"Outbound\",\"priority\":100,\"sourceAddressPrefix\":\"VirtualNetwork\",\"destinationAddressPrefix\":\"10.200.66.12\",\"sourcePortRange\":\"*\",\"destinationPortRange\":\"443\",\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[],\"sourcePortRanges\":[]}] }"
+      "value": "{ \"securityRules\": [ {\"name\":\"BastionMgmtVnet\",\"description\":\"Permit access from Bastion network\",\"direction\":\"Inbound\",\"priority\":1000,\"sourceAddressPrefix\":\"10.48.0.0/27\",\"destinationAddressPrefix\":\"VirtualNetwork\",\"sourcePortRange\":\"*\",\"destinationPortRange\":\"*\",\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[],\"sourcePortRanges\":[]} ] }"
     },
     "Dynatrace.KeyVault.Name":{
       "value": "cftptl-intsvc"

--- a/variablegroups/SBOX-AKS-Common.json
+++ b/variablegroups/SBOX-AKS-Common.json
@@ -53,12 +53,6 @@
     },
     "Subscription.AKS.NSG.Settings": {
       "value": "{ \"securityRules\": [] }"
-    },
-    "bastionSubnetPrefix": {
-      "values": "10.48.0.100"
-    },
-    "bastionSubnetNextHop": {
-      "value": "10.10.200.36"
     }
   },
   "id": 19,

--- a/variablegroups/SBOX-AKS-Common.json
+++ b/variablegroups/SBOX-AKS-Common.json
@@ -52,7 +52,7 @@
       "value": "#aks-monitor-sbox"
     },
     "Subscription.AKS.NSG.Settings": {
-      "value": "{ \"securityRules\": [] }"
+      "value": "{ \"securityRules\": [ {\"name\":\"BastionMgmtVnet\",\"description\":\"Permit access from Bastion network\",\"direction\":\"Inbound\",\"priority\":1000,\"sourceAddressPrefix\":\"10.48.0.96/27\",\"destinationAddressPrefix\":\"VirtualNetwork\",\"sourcePortRange\":\"*\",\"destinationPortRange\":\"*\",\"access\":\"Allow\",\"protocol\":\"Tcp\",\"destinationPortRanges\":[],\"sourcePortRanges\":[]} ] }"
     }
   },
   "id": 19,

--- a/variablegroups/SBOX-AKS-Common.json
+++ b/variablegroups/SBOX-AKS-Common.json
@@ -53,6 +53,12 @@
     },
     "Subscription.AKS.NSG.Settings": {
       "value": "{ \"securityRules\": [] }"
+    },
+    "bastionSubnetPrefix": {
+      "values": "10.48.0.100"
+    },
+    "bastionSubnetNextHop": {
+      "value": "10.10.200.36"
     }
   },
   "id": 19,


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ x ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

### Change description ###

This PR does the following:

- Implements a routing table for each AKS cluster
- Assigns the routing table to the primary and secondary AKS subnets, and the Iaas subnet
- Adds a route entry back to the bastion network, depending on the environment.  The next hop is defined at the hub palo alto load balancer

This change is required to allow the new bastion hosts to communicate with the AKS cluster and the the services hosted within.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
