### PR TITLE
Install flux from flux-config patches

### DIFF
--- a/scripts/install-flux.sh
+++ b/scripts/install-flux.sh
@@ -19,6 +19,7 @@ helm upgrade flux-helm-operator fluxcd/helm-operator --install --namespace admin
 curl -s "https://raw.githubusercontent.com/\
 kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
 TMP_DIR=/tmp/flux/${ENV}/${CLUSTER_NAME}
+mkdir -p $TMP_DIR
 # -----------------------------------------------------------
 (
 cat <<EOF

--- a/scripts/install-flux.sh
+++ b/scripts/install-flux.sh
@@ -35,6 +35,6 @@ EOF
 ) > "${TMP_DIR}/kustomization.yaml"
 # -----------------------------------------------------------
 
-kubectl apply -f https://raw.githubusercontent.com/hmcts/cnp-flux-config/master/k8s/$ENV/sealed-secrets/acr-credentials.yaml
+kubectl apply -f https://raw.githubusercontent.com/hmcts/cnp-flux-config/master/k8s/$ENV/common/sealed-secrets/acr-credentials.yaml
 
 ./kustomize build ${TMP_DIR} |  kubectl apply -f -

--- a/scripts/install-flux.sh
+++ b/scripts/install-flux.sh
@@ -10,11 +10,30 @@ FLUX_HELM_CRD=https://raw.githubusercontent.com/fluxcd/helm-operator/chart-1.1.0
 
 helm repo add fluxcd ${HELM_REPO}
 
-
-helm upgrade flux fluxcd/flux --install --namespace admin -f ${VALUES} --version 1.4.0 --set image.tag=1.20.0 \
-    --set "git.path=k8s/${ENV}/common\,k8s/${ENV}/${CLUSTER_NAME}\,k8s/${ENV}/${CLUSTER_NAME}-overlay\,k8s/${ENV}/common-overlay\,k8s/common",git.label=${ENV},git.email=flux-${ENV}@hmcts.net,git.user="Flux ${ENV}" \
-    --wait
-
 kubectl apply -f ${FLUX_HELM_CRD}
 kubectl -n admin delete secret flux-helm-repositories || true
 helm upgrade flux-helm-operator fluxcd/helm-operator --install --namespace admin   -f  deployments/fluxcd/helm-operator-values.yaml --version 1.1.0 --wait
+
+
+#Install kustomize
+curl -s "https://raw.githubusercontent.com/\
+kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+TMP_DIR=/tmp/flux/${ENV}/${CLUSTER_NAME}
+# -----------------------------------------------------------
+(
+cat <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: admin
+resources:
+  - https://raw.githubusercontent.com/hmcts/cnp-flux-config/master/k8s/namespaces/admin/flux/flux.yaml
+patchesStrategicMerge:
+  - https://raw.githubusercontent.com/hmcts/cnp-flux-config/master/k8s/namespaces/admin/flux/patches/${ENV}/flux.yaml
+  - https://raw.githubusercontent.com/hmcts/cnp-flux-config/master/k8s/namespaces/admin/flux/patches/${ENV}/${CLUSTER_NAME}/flux.yaml
+EOF
+) > "${TMP_DIR}/kustomization.yaml"
+# -----------------------------------------------------------
+
+kubectl apply -f https://raw.githubusercontent.com/hmcts/cnp-flux-config/master/k8s/$ENV/sealed-secrets/acr-credentials.yaml
+
+./kustomize build ${TMP_DIR} |  kubectl apply -f -


### PR DESCRIPTION
- Changes to flux are maintained at both places currently.
- went there to add `acr-credentials` change which i missed before 
- Label was also different for flux to tag the repo (it was sandbox instead of sandbox-00-aks)
- Flux doesnt need to be installed in bootstrap, it needs helm operator and sealed secrets controller installed ahead ( i will swap sealed secrets in release pipeline)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
