### PR TITLE
Changes to enable managed identity for AKS and aadprofile to managed

### DIFF
--- a/scripts/delete-aks-iam.sh
+++ b/scripts/delete-aks-iam.sh
@@ -16,7 +16,7 @@ IFS=$'\n'
 guids=()
 subs=()
 guids+=("$(jq -r .parameters.Virtual_Machine_Contributor_Iam_Guid_$AKSENV.value ../templates/vars/aks/$ENVIRONMENT.json) ")
-guids+=("$(jq -r .parameters.Contributor_Iam_Guid_$AKSENV.value ../templates/vars/aks/$ENVIRONMENT.json)")
+guids+=("$(jq -r .parameters.contributor_Iam_Guid_$AKSENV.value ../templates/vars/aks/$ENVIRONMENT.json)")
 guids+=("$(jq -r .parameters.iam.value.permissions[].guid_$AKSENV ../templates/vars/aks/$ENVIRONMENT.json)")
 subs=$(jq -r .parameters.iam.value.permissions[].subscriptionId ../templates/vars/aks/$ENVIRONMENT.json | uniq)
 

--- a/scripts/delete-aks-iam.sh
+++ b/scripts/delete-aks-iam.sh
@@ -16,7 +16,7 @@ IFS=$'\n'
 guids=()
 subs=()
 guids+=("$(jq -r .parameters.Virtual_Machine_Contributor_Iam_Guid_$AKSENV.value ../templates/vars/aks/$ENVIRONMENT.json) ")
-guids+=("$(jq -r .parameters.Network_Contributor_Iam_Guid_$AKSENV.value ../templates/vars/aks/$ENVIRONMENT.json)")
+guids+=("$(jq -r .parameters.Contributor_Iam_Guid_$AKSENV.value ../templates/vars/aks/$ENVIRONMENT.json)")
 guids+=("$(jq -r .parameters.iam.value.permissions[].guid_$AKSENV ../templates/vars/aks/$ENVIRONMENT.json)")
 subs=$(jq -r .parameters.iam.value.permissions[].subscriptionId ../templates/vars/aks/$ENVIRONMENT.json | uniq)
 

--- a/scripts/delete-aks-iam.sh
+++ b/scripts/delete-aks-iam.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+ENVIRONMENT=$1
+AKSNAME=$2
+
+if [[ $AKSNAME == *"00"* ]]
+then
+AKSENV="00"
+else
+AKSENV="01"
+fi
+
+IFS=$' '
+IFS=$'\n'
+guids=()
+subs=()
+guids+=("$(jq -r .parameters.Virtual_Machine_Contributor_Iam_Guid_$AKSENV.value ../templates/vars/aks/$ENVIRONMENT.json) ")
+guids+=("$(jq -r .parameters.Network_Contributor_Iam_Guid_$AKSENV.value ../templates/vars/aks/$ENVIRONMENT.json)")
+guids+=("$(jq -r .parameters.iam.value.permissions[].guid_$AKSENV ../templates/vars/aks/$ENVIRONMENT.json)")
+subs=$(jq -r .parameters.iam.value.permissions[].subscriptionId ../templates/vars/aks/$ENVIRONMENT.json | uniq)
+
+for sub in ${subs[@]}; 
+do
+
+echo "Setting subscription for $sub"
+az account set --subscription $sub
+
+for guid in ${guids[@]}; 
+do 
+
+ID=$(az role assignment list --all --query "[?name=='$guid'].[id]" -o tsv);
+RESOURCEGROUP=$(az role assignment list --all --query "[?name=='$guid'].[resourceGroup]" -o tsv);
+
+echo "Checking IAM Role Assignment for GUID:- $guid on subscription:- $sub in Resource Group:- $RESOURCEGROUP";
+if [ -n "${ID}" ];  then
+
+    echo "Deleting IAM Role Assignment for GUID:- $guid on subscription:- $sub in Resource Group:- $RESOURCEGROUP";
+    az role assignment delete --ids $ID ;
+    
+fi
+
+done
+
+done

--- a/templates/arm-aks-template.json
+++ b/templates/arm-aks-template.json
@@ -100,10 +100,10 @@
     "Virtual_Machine_Contributor_Iam_Guid_01": {
       "type":"string"
     },
-    "Network_Contributor_Iam_Guid_00": {
+    "contributor_Iam_Guid_00": {
       "type":"string"
     },
-    "Network_Contributor_Iam_Guid_01": {
+    "contributor_Iam_Guid_01": {
       "type":"string"
     }
   },
@@ -118,7 +118,7 @@
     "loadbalancerIpPrefix": "[concat(parameters('aksClusterName'), '-pip')]",
     "MC_RG": "[concat('MC_', resourceGroup().name, '_', parameters('aksclusterName'), '_', 'uksouth')]",
     "Virtual_Machine_Contributor": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/',  '9980e02c-c2be-4d73-94e8-173b1dc7cf3c')]",
-    "Network_Contributor": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/',  '4d97b98b-1d4f-4787-a291-c67834d212e7')]"
+    "contributor": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/',  'b24988ac-6180-42a0-ab88-20f7382dd24c')]"
   },
   "resources": [
     {
@@ -215,7 +215,7 @@
           "[resourceId('Microsoft.ContainerService/managedClusters', parameters('aksclusterName'))]"
       ],
       "apiVersion": "2020-06-01",
-      "name":"[concat(parameters('aksclusterName'), '-VM-Contributor-Iam')]",
+      "name":"[concat(parameters('aksclusterName'), '-Contributor-Iam')]",
       "resourceGroup": "[variables('MC_RG')]",
       "subscriptionId": "[subscription().subscriptionId]",
       "properties": {
@@ -262,9 +262,9 @@
           {
             "type": "Microsoft.Authorization/roleAssignments",
             "apiVersion": "2020-04-01-preview",
-            "name": "[if(contains(parameters('aksclusterName'), '00'), parameters('Network_Contributor_Iam_Guid_00'), parameters('Network_Contributor_Iam_Guid_01'))]",
+            "name": "[if(contains(parameters('aksclusterName'), '00'), parameters('contributor_Iam_Guid_00'), parameters('contributor_Iam_Guid_01'))]",
             "properties": {
-              "roleDefinitionId": "[variables('Network_Contributor')]",
+              "roleDefinitionId": "[variables('contributor')]",
               "principalId": "[reference(resourceId('Microsoft.ContainerService/managedClusters/', parameters('aksclusterName')), '2020-06-01', 'Full').identity.principalId]",
               "scope":"[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('aksVnetResourceGroup'))]",
               "principalType": "ServicePrincipal"
@@ -285,7 +285,7 @@
           "[resourceId('Microsoft.ContainerService/managedClusters', parameters('aksClusterName'))]"
       ],
       "apiVersion": "2020-06-01",
-      "name": "[concat(parameters('iam').permissions[copyIndex()].name, '-Iam-aks-sbox')]",
+      "name": "[concat(parameters('iam').permissions[copyIndex()].name, '-Iam-aks-',parameters('aksclusterName'))]",
       "resourceGroup": "[parameters('iam').permissions[copyIndex()].resourceGroup]",
       "subscriptionId": "[parameters('iam').permissions[copyIndex()].subscriptionId]",
       "properties": {

--- a/templates/arm-aks-template.json
+++ b/templates/arm-aks-template.json
@@ -215,7 +215,7 @@
           "[resourceId('Microsoft.ContainerService/managedClusters', parameters('aksclusterName'))]"
       ],
       "apiVersion": "2020-06-01",
-      "name":"[concat(parameters('aksclusterName'), '-Contributor-Iam')]",
+      "name":"[concat(parameters('aksclusterName'), '-VM-Contributor-Iam')]",
       "resourceGroup": "[variables('MC_RG')]",
       "subscriptionId": "[subscription().subscriptionId]",
       "properties": {
@@ -248,7 +248,7 @@
           "[resourceId('Microsoft.ContainerService/managedClusters', parameters('aksclusterName'))]"
       ],
       "apiVersion": "2020-06-01",
-      "name":"[concat(parameters('aksclusterName'), '-Network-Contributor-Iam')]",
+      "name":"[concat(parameters('aksclusterName'), '-Contributor-Iam')]",
       "resourceGroup": "[parameters('aksVnetResourceGroup')]",
       "subscriptionId": "[subscription().subscriptionId]",
       "properties": {

--- a/templates/arm-aks-template.json
+++ b/templates/arm-aks-template.json
@@ -47,21 +47,6 @@
     "sshPublicKey": {
       "type": "string"
     },
-    "servicePrincipalId": {
-      "type": "string"
-    },
-    "servicePrincipalSecret": {
-      "type": "string"
-    },
-    "clientAppId": {
-      "type": "string"
-    },
-    "serverAppId": {
-      "type": "string"
-    },
-    "serverAppSecret": {
-      "type": "string"
-    },
     "logAnalyticsResourceId": {
       "type": "string"
     },
@@ -105,6 +90,21 @@
     },
     "criticality": {
       "type": "string"
+    },
+    "iam": {
+      "type":"object"
+    },
+    "Virtual_Machine_Contributor_Iam_Guid_00": {
+      "type":"string"
+    },
+    "Virtual_Machine_Contributor_Iam_Guid_01": {
+      "type":"string"
+    },
+    "Network_Contributor_Iam_Guid_00": {
+      "type":"string"
+    },
+    "Network_Contributor_Iam_Guid_01": {
+      "type":"string"
     }
   },
   "variables": {
@@ -113,15 +113,22 @@
     "storageProfile": "ManagedDisks",
     "osType": "Linux",
     "adminUsername": "azureuser",
+    "nodepoolMode": "System",
     "aksVnetSubnetId": "[resourceId(parameters('aksVnetResourceGroup'),'Microsoft.Network/virtualNetworks/subnets',parameters('aksVnetName'), parameters('subnetName'))]",
-    "loadbalancerIpPrefix": "[concat(parameters('aksClusterName'), '-pip')]"
+    "loadbalancerIpPrefix": "[concat(parameters('aksClusterName'), '-pip')]",
+    "MC_RG": "[concat('MC_', resourceGroup().name, '_', parameters('aksclusterName'), '_', 'uksouth')]",
+    "Virtual_Machine_Contributor": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/',  '9980e02c-c2be-4d73-94e8-173b1dc7cf3c')]",
+    "Network_Contributor": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/',  '4d97b98b-1d4f-4787-a291-c67834d212e7')]"
   },
   "resources": [
     {
       "type": "Microsoft.ContainerService/managedClusters",
       "name": "[parameters('aksClusterName')]",
-      "apiVersion": "2019-10-01",
+      "apiVersion": "2020-04-01",
       "location": "[resourceGroup().location]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
       "tags" : {
         "EnvironmentName": "[parameters('environmentName')]",
         "Branch":"[parameters('branch')]",
@@ -153,7 +160,8 @@
             "storageProfile": "[variables('storageProfile')]",
             "maxPods": "[parameters('maxPods')]",
             "vnetSubnetID": "[variables('aksVnetSubnetId')]",
-            "osType": "[variables('osType')]"
+            "osType": "[variables('osType')]",
+            "mode": "[variables('nodepoolMode')]"
           }
         ],
         "linuxProfile": {
@@ -166,10 +174,6 @@
             ]
           }
         },
-        "servicePrincipalProfile": {
-          "clientId": "[parameters('servicePrincipalId')]",
-          "secret": "[parameters('servicePrincipalSecret')]"
-        },
         "addonProfiles": {
           "kubeDashboard": {
             "config": null,
@@ -181,12 +185,10 @@
                   "logAnalyticsWorkspaceResourceID": "[parameters('logAnalyticsResourceId')]"
               }
           }
-        },           
-        "enableRBAC": true,
+        },
         "aadProfile": {
-          "clientAppID": "[parameters('clientAppId')]",
-          "serverAppID": "[parameters('serverAppId')]",
-          "serverAppSecret": "[parameters('serverAppSecret')]",
+          "managed": true,
+          "enableAzureRBAC": true,
           "tenantID": "[subscription().tenantId]"
         },
         "networkProfile": {
@@ -205,6 +207,109 @@
             }
           }
         }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "dependsOn": [
+          "[resourceId('Microsoft.ContainerService/managedClusters', parameters('aksclusterName'))]"
+      ],
+      "apiVersion": "2020-06-01",
+      "name":"[concat(parameters('aksclusterName'), '-VM-Contributor-Iam')]",
+      "resourceGroup": "[variables('MC_RG')]",
+      "subscriptionId": "[subscription().subscriptionId]",
+      "properties": {
+      "mode": "Incremental",
+      "template": {
+        "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+        "contentVersion": "1.0.0.0",
+        "parameters": {},
+        "variables": {},
+        "resources": [
+          {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2020-04-01-preview",
+            "name":  "[if(contains(parameters('aksclusterName'), '00'), parameters('Virtual_Machine_Contributor_Iam_Guid_00'), parameters('Virtual_Machine_Contributor_Iam_Guid_01'))]",
+            "properties": {
+              "roleDefinitionId": "[variables('Virtual_Machine_Contributor')]",
+              "principalId": "[reference(parameters('aksClusterName'), '2020-03-01').identityProfile.kubeletidentity.objectId]",
+              "scope":"[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', variables('MC_RG'))]",
+              "principalType": "ServicePrincipal"
+          }
+        }
+        ]
+      },
+      "parameters": {}
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "dependsOn": [
+          "[resourceId('Microsoft.ContainerService/managedClusters', parameters('aksclusterName'))]"
+      ],
+      "apiVersion": "2020-06-01",
+      "name":"[concat(parameters('aksclusterName'), '-Network-Contributor-Iam')]",
+      "resourceGroup": "[parameters('aksVnetResourceGroup')]",
+      "subscriptionId": "[subscription().subscriptionId]",
+      "properties": {
+      "mode": "Incremental",
+      "template": {
+        "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+        "contentVersion": "1.0.0.0",
+        "parameters": {},
+        "variables": {},
+        "resources": [
+          {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2020-04-01-preview",
+            "name": "[if(contains(parameters('aksclusterName'), '00'), parameters('Network_Contributor_Iam_Guid_00'), parameters('Network_Contributor_Iam_Guid_01'))]",
+            "properties": {
+              "roleDefinitionId": "[variables('Network_Contributor')]",
+              "principalId": "[reference(resourceId('Microsoft.ContainerService/managedClusters/', parameters('aksclusterName')), '2020-06-01', 'Full').identity.principalId]",
+              "scope":"[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('aksVnetResourceGroup'))]",
+              "principalType": "ServicePrincipal"
+          }
+        }
+        ]
+      },
+      "parameters": {}
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "copy": {
+      "name": "iam_loop",
+      "count": "[length(parameters('iam').permissions)]"
+      },
+      "dependsOn": [
+          "[resourceId('Microsoft.ContainerService/managedClusters', parameters('aksClusterName'))]"
+      ],
+      "apiVersion": "2020-06-01",
+      "name": "[concat(parameters('iam').permissions[copyIndex()].name, '-Iam-aks-sbox')]",
+      "resourceGroup": "[parameters('iam').permissions[copyIndex()].resourceGroup]",
+      "subscriptionId": "[parameters('iam').permissions[copyIndex()].subscriptionId]",
+      "properties": {
+      "mode": "Incremental",
+      "template": {
+        "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+        "contentVersion": "1.0.0.0",
+        "parameters": {},
+        "variables": {},
+        "resources": [
+          {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion":  "2020-04-01-preview",
+            "name": "[if(contains(parameters('aksclusterName'), '00'), parameters('iam').permissions[copyIndex()].guid_00, parameters('iam').permissions[copyIndex()].guid_01)]",
+            "properties": {
+              "roleDefinitionId": "[parameters('iam').permissions[copyIndex()].roleDefinitionId]",
+              "principalId": "[reference(parameters('aksClusterName'), '2020-03-01').identityProfile.kubeletidentity.objectId]",
+              "scope": "[parameters('iam').permissions[copyIndex()].scope]",
+              "principalType": "ServicePrincipal"
+          }
+        }
+        ]
+      },
+      "parameters": {}
       }
     }
   ],

--- a/templates/vars/aks/aat.json
+++ b/templates/vars/aks/aat.json
@@ -19,6 +19,53 @@
     },
     "vmSize": {
       "value": "Standard_D4s_v3"
-    }
+    },
+    "Virtual_Machine_Contributor_Iam_Guid_00": {
+      "value": "95a8ca8d-fc14-46e2-a2f6-0c4ff15d4787"
+    },
+    "Virtual_Machine_Contributor_Iam_Guid_01": {
+      "value": "5e8ef72b-d386-48cd-bbd1-16e5addc914a"
+    },
+    "contributor_Iam_Guid_00": {
+      "value": "d61ec3ac-af3c-46c6-9206-023a6354d529"
+    },
+    "contributor_Iam_Guid_01": {
+      "value": "1ff27be3-31c0-4110-acfc-0001380e5753"
+    },
+    "iam": {
+      "value": {
+          "permissions": [
+          {
+            "name": "ManagedIdentityOperator1",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+            "resourcegroup": "managed-identities-aat-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "09c66f62-fd07-4e9c-92b0-47c44ff5acbb",
+            "guid_01": "b278b48a-47ea-45ae-89ca-4caa157274fd",
+            "subscriptionId": "96c274ce-846d-4e48-89a7-d528432298a7"
+          },
+          {
+            "name": "ManagedIdentityOperator2",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+            "resourcegroup": "managed-identities-aat-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "efed6bc4-823f-453e-a8a7-99873f678d37",
+            "guid_01": "f25921d9-c4cb-4797-91fe-52412b172b41",
+            "subscriptionId": "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+          },
+          {
+            "name": "AcrPull",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
+            "resourcegroup": "rpe-acr-prod-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "1ec3264a-5eae-47b8-b173-9a8fb4aeef2d",
+            "guid_01": "224b8d74-ccd6-4219-868f-cb6403ad9dea",
+            "subscriptionId": "8999dec3-0104-4a27-94ee-6588559729d1"
+          }
+
+          ]
+        }
+      }
+  
   }
 }

--- a/templates/vars/aks/cftsbox-intsvc.json
+++ b/templates/vars/aks/cftsbox-intsvc.json
@@ -26,10 +26,10 @@
       "Virtual_Machine_Contributor_Iam_Guid_01": {
         "value": "8a674ba8-4b28-4b78-bab7-e4de9ad19d36"
       },
-      "Network_Contributor_Iam_Guid_00": {
+      "contributor_Iam_Guid_00": {
         "value": "19a91d28-051e-4fee-9e9e-130eb6295ff5"
       },
-      "Network_Contributor_Iam_Guid_01": {
+      "contributor_Iam_Guid_01": {
         "value": "cd68747e-8f54-48db-9531-20b5b2f20b74"
       },
       "iam": {

--- a/templates/vars/aks/cftsbox-intsvc.json
+++ b/templates/vars/aks/cftsbox-intsvc.json
@@ -19,6 +19,44 @@
     },
     "vmSize": {
       "value": "Standard_D4s_v3"
+    },
+      "Virtual_Machine_Contributor_Iam_Guid_00": {
+        "value": "c17867b7-2edd-4ee5-8071-c0d84b6f5d68"
+      },
+      "Virtual_Machine_Contributor_Iam_Guid_01": {
+        "value": "8a674ba8-4b28-4b78-bab7-e4de9ad19d36"
+      },
+      "Network_Contributor_Iam_Guid_00": {
+        "value": "19a91d28-051e-4fee-9e9e-130eb6295ff5"
+      },
+      "Network_Contributor_Iam_Guid_01": {
+        "value": "cd68747e-8f54-48db-9531-20b5b2f20b74"
+      },
+      "iam": {
+        "value": {
+            "permissions": [
+            {
+              "name": "ManagedIdentityOperator1",        
+              "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+              "resourcegroup": "managed-identities-cftsbox-intsvc-rg",
+              "scope": "[resourceGroup().id]",
+              "guid_00": "83b18791-84ae-433f-a525-522020e5615a",
+              "guid_01": "c88b74f0-61b2-4b26-a4aa-54992ac6a9a8",
+              "subscriptionId": "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
+            },
+            {
+              "name": "AcrPull",        
+              "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
+              "resourcegroup": "rpe-acr-prod-rg",
+              "scope": "[resourceGroup().id]",
+              "guid_00": "2a8ea42e-748b-48a6-8994-cf9c6163385d",
+              "guid_01": "761661d2-27ce-40c8-b8b1-f50c2935a5ae",
+              "subscriptionId": "8999dec3-0104-4a27-94ee-6588559729d1"
+            }
+            ]
+          }
+        }
+      
+      }
     }
-  }
-}
+  

--- a/templates/vars/aks/cftsbox-intsvc.json
+++ b/templates/vars/aks/cftsbox-intsvc.json
@@ -20,43 +20,43 @@
     "vmSize": {
       "value": "Standard_D4s_v3"
     },
-      "Virtual_Machine_Contributor_Iam_Guid_00": {
-        "value": "c17867b7-2edd-4ee5-8071-c0d84b6f5d68"
-      },
-      "Virtual_Machine_Contributor_Iam_Guid_01": {
-        "value": "8a674ba8-4b28-4b78-bab7-e4de9ad19d36"
-      },
-      "contributor_Iam_Guid_00": {
-        "value": "19a91d28-051e-4fee-9e9e-130eb6295ff5"
-      },
-      "contributor_Iam_Guid_01": {
-        "value": "cd68747e-8f54-48db-9531-20b5b2f20b74"
-      },
-      "iam": {
-        "value": {
-            "permissions": [
-            {
-              "name": "ManagedIdentityOperator1",        
-              "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
-              "resourcegroup": "managed-identities-cftsbox-intsvc-rg",
-              "scope": "[resourceGroup().id]",
-              "guid_00": "83b18791-84ae-433f-a525-522020e5615a",
-              "guid_01": "c88b74f0-61b2-4b26-a4aa-54992ac6a9a8",
-              "subscriptionId": "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
-            },
-            {
-              "name": "AcrPull",        
-              "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
-              "resourcegroup": "rpe-acr-prod-rg",
-              "scope": "[resourceGroup().id]",
-              "guid_00": "2a8ea42e-748b-48a6-8994-cf9c6163385d",
-              "guid_01": "761661d2-27ce-40c8-b8b1-f50c2935a5ae",
-              "subscriptionId": "8999dec3-0104-4a27-94ee-6588559729d1"
-            }
-            ]
+    "Virtual_Machine_Contributor_Iam_Guid_00": {
+      "value": "c17867b7-2edd-4ee5-8071-c0d84b6f5d68"
+    },
+    "Virtual_Machine_Contributor_Iam_Guid_01": {
+      "value": "8a674ba8-4b28-4b78-bab7-e4de9ad19d36"
+    },
+    "contributor_Iam_Guid_00": {
+      "value": "19a91d28-051e-4fee-9e9e-130eb6295ff5"
+    },
+    "contributor_Iam_Guid_01": {
+      "value": "cd68747e-8f54-48db-9531-20b5b2f20b74"
+    },
+    "iam": {
+      "value": {
+          "permissions": [
+          {
+            "name": "ManagedIdentityOperator1",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+            "resourcegroup": "managed-identities-cftsbox-intsvc-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "83b18791-84ae-433f-a525-522020e5615a",
+            "guid_01": "c88b74f0-61b2-4b26-a4aa-54992ac6a9a8",
+            "subscriptionId": "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
+          },
+          {
+            "name": "AcrPull",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
+            "resourcegroup": "rpe-acr-prod-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "2a8ea42e-748b-48a6-8994-cf9c6163385d",
+            "guid_01": "761661d2-27ce-40c8-b8b1-f50c2935a5ae",
+            "subscriptionId": "8999dec3-0104-4a27-94ee-6588559729d1"
           }
+          ]
         }
-      
       }
-    }
+  
+  }
+}
   

--- a/templates/vars/aks/ithc.json
+++ b/templates/vars/aks/ithc.json
@@ -19,6 +19,43 @@
     },
     "vmSize": {
       "value": "Standard_D4s_v3"
-    }
+    },
+    "Virtual_Machine_Contributor_Iam_Guid_00": {
+      "value": "8cccbafb-f6ae-4ef5-8a7d-fdca8d050860"
+    },
+    "Virtual_Machine_Contributor_Iam_Guid_01": {
+      "value": "0667fee4-378a-4465-a9dd-b50b27380c3e"
+    },
+    "contributor_Iam_Guid_00": {
+      "value": "1fbf4599-1a09-4fd9-909e-e5669477516c"
+    },
+    "contributor_Iam_Guid_01": {
+      "value": "7b53fad4-bcf1-4b63-a006-92ef0788ea3c"
+    },
+    "iam": {
+      "value": {
+          "permissions": [
+          {
+            "name": "ManagedIdentityOperator1",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+            "resourcegroup": "managed-identities-ithc-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "eb01c794-f776-4588-a306-accb42d59626",
+            "guid_01": "f89ae6e1-f8a5-485b-b6e6-50963a657e60",
+            "subscriptionId": "62864d44-5da9-4ae9-89e7-0cf33942fa09"
+          },
+          {
+            "name": "AcrPull",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
+            "resourcegroup": "rpe-acr-prod-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "86885a49-2753-410f-8710-df3ad70fb390",
+            "guid_01": "ed5d74e9-2594-4759-808b-216511eebfc3",
+            "subscriptionId": "8999dec3-0104-4a27-94ee-6588559729d1"
+          }
+          ]
+        }
+      }
+  
   }
 }

--- a/templates/vars/aks/ithc.json
+++ b/templates/vars/aks/ithc.json
@@ -45,6 +45,24 @@
             "subscriptionId": "62864d44-5da9-4ae9-89e7-0cf33942fa09"
           },
           {
+            "name": "ManagedIdentityOperator2",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+            "resourcegroup": "managed-identities-demo-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "4db8205b-8087-4798-aea8-96608742f038",
+            "guid_01": "463d5224-ebbe-429d-a806-4bf1da99368a",
+            "subscriptionId": "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+          },
+          {
+            "name": "ManagedIdentityOperator3",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+            "resourcegroup": "managed-identities-ithc-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "759f7db3-8204-4301-9650-2157bcd93b35",
+            "guid_01": "4678b86b-1008-4944-913d-47ede35864f8",
+            "subscriptionId": "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
+          },
+          {
             "name": "AcrPull",        
             "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
             "resourcegroup": "rpe-acr-prod-rg",

--- a/templates/vars/aks/ithc.json
+++ b/templates/vars/aks/ithc.json
@@ -51,7 +51,7 @@
             "scope": "[resourceGroup().id]",
             "guid_00": "4db8205b-8087-4798-aea8-96608742f038",
             "guid_01": "463d5224-ebbe-429d-a806-4bf1da99368a",
-            "subscriptionId": "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+            "subscriptionId": "62864d44-5da9-4ae9-89e7-0cf33942fa09"
           },
           {
             "name": "ManagedIdentityOperator3",        

--- a/templates/vars/aks/ithc.json
+++ b/templates/vars/aks/ithc.json
@@ -45,15 +45,6 @@
             "subscriptionId": "62864d44-5da9-4ae9-89e7-0cf33942fa09"
           },
           {
-            "name": "ManagedIdentityOperator2",        
-            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
-            "resourcegroup": "managed-identities-demo-rg",
-            "scope": "[resourceGroup().id]",
-            "guid_00": "4db8205b-8087-4798-aea8-96608742f038",
-            "guid_01": "463d5224-ebbe-429d-a806-4bf1da99368a",
-            "subscriptionId": "62864d44-5da9-4ae9-89e7-0cf33942fa09"
-          },
-          {
             "name": "ManagedIdentityOperator3",        
             "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
             "resourcegroup": "managed-identities-ithc-rg",

--- a/templates/vars/aks/preview.json
+++ b/templates/vars/aks/preview.json
@@ -57,6 +57,15 @@
             "subscriptionId": "1c4f0704-a29e-403d-b719-b90c34ef14c9"
           },
           {
+            "name": "ManagedIdentityOperator3",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+            "resourcegroup": "managed-identities-preview-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "1373f3fd-1f22-4345-aae3-b24972533a8f",
+            "guid_01": "b17d8129-d482-4842-a4b4-7ce06b157f8f",
+            "subscriptionId": "8b6ea922-0862-443e-af15-6056e1c9b9a4"
+          },
+          {
             "name": "AcrPull",        
             "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
             "resourcegroup": "rpe-acr-prod-rg",
@@ -65,6 +74,7 @@
             "guid_01": "3d05e35c-04c4-4513-9746-daebae4cd085",
             "subscriptionId": "8999dec3-0104-4a27-94ee-6588559729d1"
           }
+
           ]
         }
       }

--- a/templates/vars/aks/preview.json
+++ b/templates/vars/aks/preview.json
@@ -22,6 +22,52 @@
     },
     "vmSize": {
       "value": "Standard_D4s_v3"
-    }
+    },
+    "Virtual_Machine_Contributor_Iam_Guid_00": {
+      "value": "afa59330-39cf-4941-b1f4-9b27c6a365a9"
+    },
+    "Virtual_Machine_Contributor_Iam_Guid_01": {
+      "value": "26b0b13a-28f3-491c-8335-430046efdf1b"
+    },
+    "contributor_Iam_Guid_00": {
+      "value": "f5e8e541-1b33-4306-8d7a-08f76c142e1e"
+    },
+    "contributor_Iam_Guid_01": {
+      "value": "7848fe45-12b1-4858-84aa-c4c22a24d79b"
+    },
+    "iam": {
+      "value": {
+          "permissions": [
+          {
+            "name": "ManagedIdentityOperator1",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+            "resourcegroup": "managed-identities-aat-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "e88f9703-cc9b-4aff-968e-de9b08ac0ebf",
+            "guid_01": "724b0811-aa2d-45c7-ba69-ab90ea1ee59e",
+            "subscriptionId": "96c274ce-846d-4e48-89a7-d528432298a7"
+          },
+          {
+            "name": "ManagedIdentityOperator2",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+            "resourcegroup": "managed-identities-aat-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "515bc41e-1804-4ce4-9edb-273da71a7dc0",
+            "guid_01": "86b9bc97-a964-4520-b7c1-533c908c592e",
+            "subscriptionId": "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+          },
+          {
+            "name": "AcrPull",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
+            "resourcegroup": "rpe-acr-prod-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "45fb14e8-3317-4695-8c0b-23c502eba1fa",
+            "guid_01": "3d05e35c-04c4-4513-9746-daebae4cd085",
+            "subscriptionId": "8999dec3-0104-4a27-94ee-6588559729d1"
+          }
+          ]
+        }
+      }
+  
   }
 }

--- a/templates/vars/aks/prod.json
+++ b/templates/vars/aks/prod.json
@@ -19,6 +19,53 @@
     },
     "vmSize": {
       "value": "Standard_D4s_v3"
-    }
+    },
+    "Virtual_Machine_Contributor_Iam_Guid_00": {
+      "value": "4513a238-65cc-4287-9405-542398b5cedf"
+    },
+    "Virtual_Machine_Contributor_Iam_Guid_01": {
+      "value": "47389c7c-24a4-40fe-93e4-6913cae34888"
+    },
+    "contributor_Iam_Guid_00": {
+      "value": "b84646fe-ebb3-4281-9e2b-fc3053b78ad4"
+    },
+    "contributor_Iam_Guid_01": {
+      "value": "f463282c-efbb-4688-a806-d57078deeff6"
+    },
+    "iam": {
+      "value": {
+          "permissions": [
+          {
+            "name": "ManagedIdentityOperator1",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+            "resourcegroup": "managed-identities-prod-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "1f7358c1-aa52-46ea-81c6-9cf283d0938c",
+            "guid_01": "5f0020f6-c7b7-49f4-8683-9d35c517c59d",
+            "subscriptionId": "8999dec3-0104-4a27-94ee-6588559729d1"
+          },
+          {
+            "name": "ManagedIdentityOperator2",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+            "resourcegroup": "managed-identities-prod-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "b897be3e-74e9-40ed-a0c3-866efbf3580f",
+            "guid_01": "6fa26418-cb70-44e6-bee2-0dceec4fbef4",
+            "subscriptionId": "8cbc6f36-7c56-4963-9d36-739db5d00b27"
+          },
+          {
+            "name": "AcrPull",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
+            "resourcegroup": "rpe-acr-prod-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "ff236018-d776-4ca8-a8d5-5d63c3e1397c",
+            "guid_01": "9021206a-0893-4a64-802e-bb3e3a27b4fc",
+            "subscriptionId": "8999dec3-0104-4a27-94ee-6588559729d1"
+          }
+
+          ]
+        }
+      }
+  
   }
 }

--- a/templates/vars/aks/sbox.json
+++ b/templates/vars/aks/sbox.json
@@ -26,10 +26,10 @@
     "Virtual_Machine_Contributor_Iam_Guid_01": {
       "value": "93807473-a718-49db-8985-3db1315a0e34"
     },
-    "Network_Contributor_Iam_Guid_00": {
+    "contributor_Iam_Guid_00": {
       "value": "b3cfa4d5-46ea-4ebd-8daf-8be3d014da0c"
     },
-    "Network_Contributor_Iam_Guid_01": {
+    "contributor_Iam_Guid_01": {
       "value": "3276d396-c475-459f-8324-572e59d220d8"
     },
     "iam": {

--- a/templates/vars/aks/sbox.json
+++ b/templates/vars/aks/sbox.json
@@ -19,6 +19,53 @@
     },
     "vmSize": {
       "value": "Standard_B4ms"
+    },
+    "Virtual_Machine_Contributor_Iam_Guid_00": {
+      "value": "abf6414c-9bcc-4508-ac79-98361bd72cd8"
+    },
+    "Virtual_Machine_Contributor_Iam_Guid_01": {
+      "value": "93807473-a718-49db-8985-3db1315a0e34"
+    },
+    "Network_Contributor_Iam_Guid_00": {
+      "value": "b3cfa4d5-46ea-4ebd-8daf-8be3d014da0c"
+    },
+    "Network_Contributor_Iam_Guid_01": {
+      "value": "3276d396-c475-459f-8324-572e59d220d8"
+    },
+    "iam": {
+      "value": {
+          "permissions": [
+          {
+            "name": "ManagedIdentityOperator1",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+            "resourcegroup": "managed-identities-sbox-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "ef17c0cc-64a9-42d3-8ddb-2e966a580289",
+            "guid_01": "9cb8c3d7-0aad-457b-9f40-4c7e5d1e9c99",
+            "subscriptionId": "b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb"
+          },
+          {
+            "name": "ManagedIdentityOperator2",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+            "resourcegroup": "managed-identities-sandbox-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "5d24677a-62b3-4bb4-bb23-a23a008e403d",
+            "guid_01": "dbf0790b-a8a2-4fbd-a1db-4113d925bf30",
+            "subscriptionId": "bf308a5c-0624-4334-8ff8-8dca9fd43783"
+          },
+          {
+            "name": "AcrPull",        
+            "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
+            "resourcegroup": "rpe-acr-prod-rg",
+            "scope": "[resourceGroup().id]",
+            "guid_00": "b3c2e5a4-e223-400d-9560-2c93cbb60026",
+            "guid_01": "5e011c3f-c9a6-4baa-aa6f-6037190b9760",
+            "subscriptionId": "8999dec3-0104-4a27-94ee-6588559729d1"
+          }
+          ]
+        }
+      }
+    
     }
   }
-}
+


### PR DESCRIPTION
### Change description ###
Swapping AKS from service principals to managed identities &  AAD V2
DevOps user stories:-
1138 - Update Azure DevOps AKS pipeline task group for AADv2 cluster upgrade
1133 - Automation of IAM permissions required as part of AKS Managed Identity


**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
