### PR TITLE
Internet traffic to Palo Alto with some additional fixes

### DIFF
--- a/templates/arm-vnet-template.json
+++ b/templates/arm-vnet-template.json
@@ -122,7 +122,7 @@
     "routetableRoutes": {
       "type": "array",
       "metadata": {
-        "description": "The address prefix of the bastion subnet"
+        "description": "The route table routes array from parameters file"
       }
     }
   },

--- a/templates/arm-vnet-template.json
+++ b/templates/arm-vnet-template.json
@@ -119,22 +119,16 @@
       "type": "array",
       "defaultValue": []
     },
-    "routes": {
+    "routetableName": {
+      "type": "string",
+      "metadata": {
+        "description": "The full ID of the hub vnet to peer to"
+      }
+    },
+    "routetableRoutes": {
       "type": "array",
       "metadata": {
         "description": "The address prefix of the bastion subnet"
-      }
-    },
-    "bastionSubnetPrefix": {
-      "type": "string",
-      "metadata": {
-        "description": "The address prefix of the bastion subnet"
-      }
-    },
-    "paloaltoIPNextHop": {
-      "type": "string",
-      "metadata": {
-        "description": "The next hop to reach the bastion vnet (Hub network; Palo Alto Load Balancer)"
       }
     }
   },
@@ -142,8 +136,6 @@
   "variables": {
     "primarySubnetName": "[concat('aks-',parameters('aksPrimarySubnetName'))]",
     "secondarySubnetName": "[concat('aks-',parameters('aksSecondarySubnetName'))]",
-    "routeTableName": "aks-route-table",
-    "internetcidr": "0.0.0.0/0",
     "nsgRulesMapping": {
       "true": "[parameters('aksNetworkSecurityGroupsSettings').securityRules]",
       "false": [{
@@ -317,7 +309,7 @@
     },
     {
       "type": "Microsoft.Network/routeTables",
-      "name": "[variables('routeTableName')]",
+      "name": "[parameters('routeTableName')]",
       "apiVersion": "2020-05-01",
       "location": "[resourceGroup().location]",
       "tags" : {
@@ -337,13 +329,13 @@
           "copy": [
               {
                   "name": "routes",
-                  "count": "[length(parameters('routes'))]",
+                  "count": "[length(parameters('routeTableRoutes'))]",
                   "input": {
-                      "name": "[parameters('routes')[copyIndex('routes')].name]",
+                      "name": "[parameters('routeTableRoutes')[copyIndex('routes')].name]",
                       "properties": {
-                          "addressPrefix": "[parameters('routes')[copyIndex('routes')].addressPrefix]",
-                          "nextHopType": "[parameters('routes')[copyIndex('routes')].nextHopType]",
-                          "nextHopIpAddress": "[parameters('routes')[copyIndex('routes')].nextHopIpAddress]"
+                          "addressPrefix": "[parameters('routeTableRoutes')[copyIndex('routes')].addressPrefix]",
+                          "nextHopType": "[parameters('routeTableRoutes')[copyIndex('routes')].nextHopType]",
+                          "nextHopIpAddress": "[parameters('routeTableRoutes')[copyIndex('routes')].nextHopIpAddress]"
                       }
                   }
               }

--- a/templates/arm-vnet-template.json
+++ b/templates/arm-vnet-template.json
@@ -397,7 +397,7 @@
               "addressPrefix": "[parameters('appgwSubnetCIDR')]",
               "serviceEndpoints": "[parameters('serviceEndpoints')]",
               "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('appgwNsgName'))]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('appgwNsgName'))]"
               }
             }
           },

--- a/templates/arm-vnet-template.json
+++ b/templates/arm-vnet-template.json
@@ -119,6 +119,12 @@
       "type": "array",
       "defaultValue": []
     },
+    "routes": {
+      "type": "array",
+      "metadata": {
+        "description": "The address prefix of the bastion subnet"
+      }
+    },
     "bastionSubnetPrefix": {
       "type": "string",
       "metadata": {
@@ -326,25 +332,22 @@
         "environment": "[parameters('environment')]",
         "criticality": "[parameters('criticality')]"
       },
+
       "properties": {
-        "routes": [
-          {
-            "name": "BastionMgmtVnet",
-            "properties": {
-              "addressPrefix": "[parameters('bastionSubnetPrefix')]",
-              "nextHopType": "VirtualAppliance",
-              "nextHopIpAddress": "[parameters('paloaltoIPNextHop')]"
-            }
-          },
-          {
-            "name": "Internet",
-            "properties": {
-              "addressPrefix": "[variables('internetcidr')]",
-              "nextHopType": "VirtualAppliance",
-              "nextHopIpAddress": "[parameters('paloaltoIPNextHop')]"
-            }
-          }
-        ]
+          "copy": [
+              {
+                  "name": "routes",
+                  "count": "[length(parameters('routes'))]",
+                  "input": {
+                      "name": "[parameters('routes')[copyIndex('routes')].name]",
+                      "properties": {
+                          "addressPrefix": "[parameters('routes')[copyIndex('routes')].addressPrefix]",
+                          "nextHopType": "[parameters('routes')[copyIndex('routes')].nextHopType]",
+                          "nextHopIpAddress": "[parameters('routes')[copyIndex('routes')].nextHopIpAddress]"
+                      }
+                  }
+              }
+          ]
       }
     },
     {

--- a/templates/arm-vnet-template.json
+++ b/templates/arm-vnet-template.json
@@ -408,9 +408,6 @@
               "serviceEndpoints": "[parameters('serviceEndpoints')]",
               "networkSecurityGroup": {
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('appgwNsgName'))]"
-              },
-              "routeTable": {
-                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
               }
             }
           },
@@ -421,6 +418,9 @@
               "serviceEndpoints": "[parameters('serviceEndpoints')]",
               "networkSecurityGroup": {
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('iaasNsgName'))]"
+              },
+              "routeTable": {
+                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
               }
             }
           }

--- a/templates/arm-vnet-template.json
+++ b/templates/arm-vnet-template.json
@@ -379,7 +379,7 @@
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('aksNsgName'))]"
               },
               "routeTable": {
-                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
+                "id": "[resourceId('Microsoft.Network/routeTables', parameters('routeTableName'))]"
               }
             }
           },
@@ -392,7 +392,7 @@
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('aksNsgName'))]"
               },
               "routeTable": {
-                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
+                "id": "[resourceId('Microsoft.Network/routeTables', parameters('routeTableName'))]"
               }
             }
           },
@@ -415,7 +415,7 @@
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('iaasNsgName'))]"
               },
               "routeTable": {
-                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
+                "id": "[resourceId('Microsoft.Network/routeTables', parameters('routeTableName'))]"
               }
             }
           }
@@ -480,7 +480,7 @@
         "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('aksNsgName'))]",
         "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('appgwNsgName'))]",
         "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('iaasNsgName'))]",
-        "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
+        "[resourceId('Microsoft.Network/routeTables', parameters('routeTableName'))]"
       ]
     },
     {

--- a/templates/arm-vnet-template.json
+++ b/templates/arm-vnet-template.json
@@ -119,12 +119,6 @@
       "type": "array",
       "defaultValue": []
     },
-    "routetableName": {
-      "type": "string",
-      "metadata": {
-        "description": "The full ID of the hub vnet to peer to"
-      }
-    },
     "routetableRoutes": {
       "type": "array",
       "metadata": {
@@ -309,7 +303,7 @@
     },
     {
       "type": "Microsoft.Network/routeTables",
-      "name": "[parameters('routeTableName')]",
+      "name": "aks-route-table",
       "apiVersion": "2020-05-01",
       "location": "[resourceGroup().location]",
       "tags" : {

--- a/templates/arm-vnet-template.json
+++ b/templates/arm-vnet-template.json
@@ -118,11 +118,26 @@
     "serviceEndpoints": {
       "type": "array",
       "defaultValue": []
+    },
+    "bastionSubnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The address prefix of the bastion subnet"
+      }
+    },
+    "paloaltoIPNextHop": {
+      "type": "string",
+      "metadata": {
+        "description": "The next hop to reach the bastion vnet (Hub network; Palo Alto Load Balancer)"
+      }
     }
   },
+  
   "variables": {
     "primarySubnetName": "[concat('aks-',parameters('aksPrimarySubnetName'))]",
     "secondarySubnetName": "[concat('aks-',parameters('aksSecondarySubnetName'))]",
+    "routeTableName": "aks-route-table",
+    "internetcidr": "0.0.0.0/0",
     "nsgRulesMapping": {
       "true": "[parameters('aksNetworkSecurityGroupsSettings').securityRules]",
       "false": [{
@@ -295,6 +310,44 @@
       ]
     },
     {
+      "type": "Microsoft.Network/routeTables",
+      "name": "[variables('routeTableName')]",
+      "apiVersion": "2020-05-01",
+      "location": "[resourceGroup().location]",
+      "tags" : {
+        "EnvironmentName": "[parameters('environmentName')]",
+        "Branch":"[parameters('branch')]",
+        "managedBy":"[parameters('managedBy')]",
+        "solutionOwner": "[parameters('solutionOwner')]",
+        "activityName": "[parameters('activityName')]",
+        "dataClassification":"[parameters('dataClassification')]",
+        "automation": "[parameters('automation')]",
+        "costCentre":"[parameters('costCentre')]",
+        "environment": "[parameters('environment')]",
+        "criticality": "[parameters('criticality')]"
+      },
+      "properties": {
+        "routes": [
+          {
+            "name": "BastionMgmtVnet",
+            "properties": {
+              "addressPrefix": "[parameters('bastionSubnetPrefix')]",
+              "nextHopType": "VirtualAppliance",
+              "nextHopIpAddress": "[parameters('paloaltoIPNextHop')]"
+            }
+          },
+          {
+            "name": "Internet",
+            "properties": {
+              "addressPrefix": "[variables('internetcidr')]",
+              "nextHopType": "VirtualAppliance",
+              "nextHopIpAddress": "[parameters('paloaltoIPNextHop')]"
+            }
+          }
+        ]
+      }
+    },
+    {
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('aksVnetName')]",
       "apiVersion": "2019-04-01",
@@ -329,6 +382,9 @@
               "serviceEndpoints": "[parameters('serviceEndpoints')]",
               "networkSecurityGroup": {
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('aksNsgName'))]"
+              },
+              "routeTable": {
+                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
               }
             }
           },
@@ -339,6 +395,9 @@
               "serviceEndpoints": "[parameters('serviceEndpoints')]",
               "networkSecurityGroup": {
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('aksNsgName'))]"
+              },
+              "routeTable": {
+                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
               }
             }
           },
@@ -349,6 +408,9 @@
               "serviceEndpoints": "[parameters('serviceEndpoints')]",
               "networkSecurityGroup": {
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('appgwNsgName'))]"
+              },
+              "routeTable": {
+                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
               }
             }
           },
@@ -422,7 +484,8 @@
       "dependsOn": [
         "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('aksNsgName'))]",
         "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('appgwNsgName'))]",
-        "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('iaasNsgName'))]"
+        "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('iaasNsgName'))]",
+        "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
       ]
     },
     {

--- a/templates/arm-vnet-template.json
+++ b/templates/arm-vnet-template.json
@@ -130,6 +130,7 @@
   "variables": {
     "primarySubnetName": "[concat('aks-',parameters('aksPrimarySubnetName'))]",
     "secondarySubnetName": "[concat('aks-',parameters('aksSecondarySubnetName'))]",
+    "routeTableName": "aks-route-table",
     "nsgRulesMapping": {
       "true": "[parameters('aksNetworkSecurityGroupsSettings').securityRules]",
       "false": [{
@@ -303,7 +304,7 @@
     },
     {
       "type": "Microsoft.Network/routeTables",
-      "name": "aks-route-table",
+      "name": "[variables('routeTableName')]",
       "apiVersion": "2020-05-01",
       "location": "[resourceGroup().location]",
       "tags" : {
@@ -373,7 +374,7 @@
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('aksNsgName'))]"
               },
               "routeTable": {
-                "id": "[resourceId('Microsoft.Network/routeTables', parameters('routeTableName'))]"
+                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
               }
             }
           },
@@ -386,7 +387,7 @@
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('aksNsgName'))]"
               },
               "routeTable": {
-                "id": "[resourceId('Microsoft.Network/routeTables', parameters('routeTableName'))]"
+                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
               }
             }
           },
@@ -396,7 +397,7 @@
               "addressPrefix": "[parameters('appgwSubnetCIDR')]",
               "serviceEndpoints": "[parameters('serviceEndpoints')]",
               "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('appgwNsgName'))]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('appgwNsgName'))]"
               }
             }
           },
@@ -409,7 +410,7 @@
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('iaasNsgName'))]"
               },
               "routeTable": {
-                "id": "[resourceId('Microsoft.Network/routeTables', parameters('routeTableName'))]"
+                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
               }
             }
           }
@@ -474,7 +475,7 @@
         "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('aksNsgName'))]",
         "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('appgwNsgName'))]",
         "[resourceId('Microsoft.Network/networkSecurityGroups',parameters('iaasNsgName'))]",
-        "[resourceId('Microsoft.Network/routeTables', parameters('routeTableName'))]"
+        "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
       ]
     },
     {

--- a/templates/vars/vnet/aat.json
+++ b/templates/vars/vnet/aat.json
@@ -66,6 +66,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.0/27"
+    },
+    "paloaltoIPNextHop": {
+      "value": "10.11.8.36"
     }
   }
 }

--- a/templates/vars/vnet/aat.json
+++ b/templates/vars/vnet/aat.json
@@ -67,11 +67,24 @@
         }
       ]
     },
-    "bastionSubnetPrefix": {
-      "value": "10.48.0.0/27"
+    "routetableName": {
+      "value": "aks-route-table"
     },
-    "paloaltoIPNextHop": {
-      "value": "10.11.8.36"
-    }
+    "routetableRoutes": {
+      "value": [
+          {
+          "name": "BastionMgmtVnet",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.11.8.36",
+          "addressPrefix": "10.48.0.0/27"
+          },
+          {
+          "name": "Internet",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.11.8.36",
+          "addressPrefix": "0.0.0.0/0"
+        }
+      ]
+  }
   }
 }

--- a/templates/vars/vnet/aat.json
+++ b/templates/vars/vnet/aat.json
@@ -75,12 +75,6 @@
     "routetableRoutes": {
       "value": [
           {
-          "name": "BastionMgmtVnet",
-          "nextHopType": "VirtualAppliance",
-          "nextHopIpAddress": "10.11.8.36",
-          "addressPrefix": "10.48.0.0/27"
-          },
-          {
           "name": "Internet",
           "nextHopType": "VirtualAppliance",
           "nextHopIpAddress": "10.11.8.36",

--- a/templates/vars/vnet/aat.json
+++ b/templates/vars/vnet/aat.json
@@ -67,9 +67,6 @@
         }
       ]
     },
-    "routetableName": {
-      "value": "aks-route-table"
-    },
     "routetableRoutes": {
       "value": [
           {

--- a/templates/vars/vnet/cftptl-intsvc.json
+++ b/templates/vars/vnet/cftptl-intsvc.json
@@ -133,12 +133,6 @@
     "routetableRoutes": {
       "value": [
           {
-          "name": "BastionMgmtVnet",
-          "nextHopType": "VirtualAppliance",
-          "nextHopIpAddress": "10.11.8.36",
-          "addressPrefix": "10.48.0.0/27"
-          },
-          {
           "name": "Internet",
           "nextHopType": "VirtualAppliance",
           "nextHopIpAddress": "10.11.8.36",

--- a/templates/vars/vnet/cftptl-intsvc.json
+++ b/templates/vars/vnet/cftptl-intsvc.json
@@ -137,6 +137,12 @@
           "nextHopType": "VirtualAppliance",
           "nextHopIpAddress": "10.11.8.36",
           "addressPrefix": "0.0.0.0/0"
+        },
+        {
+          "name": "sdsdev",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.11.72.36",
+          "addressPrefix": "10.145.0.0/18"
         }
       ]
   }

--- a/templates/vars/vnet/cftptl-intsvc.json
+++ b/templates/vars/vnet/cftptl-intsvc.json
@@ -129,6 +129,22 @@
           "service": "Microsoft.AzureCosmosDB"
         }
       ]
-    }
+    },
+    "routetableRoutes": {
+      "value": [
+          {
+          "name": "BastionMgmtVnet",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.11.8.36",
+          "addressPrefix": "10.48.0.0/27"
+          },
+          {
+          "name": "Internet",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.11.8.36",
+          "addressPrefix": "0.0.0.0/0"
+        }
+      ]
+  }
   }
 }

--- a/templates/vars/vnet/cftptl-intsvc.json
+++ b/templates/vars/vnet/cftptl-intsvc.json
@@ -137,12 +137,6 @@
           "nextHopType": "VirtualAppliance",
           "nextHopIpAddress": "10.11.8.36",
           "addressPrefix": "0.0.0.0/0"
-        },
-        {
-          "name": "sdsdev",
-          "nextHopType": "VirtualAppliance",
-          "nextHopIpAddress": "10.11.72.36",
-          "addressPrefix": "10.145.0.0/18"
         }
       ]
   }

--- a/templates/vars/vnet/cftsbox-intsvc.json
+++ b/templates/vars/vnet/cftsbox-intsvc.json
@@ -55,12 +55,6 @@
     "routetableRoutes": {
       "value": [
           {
-          "name": "BastionMgmtVnet",
-          "nextHopType": "VirtualAppliance",
-          "nextHopIpAddress": "10.10.200.36",
-          "addressPrefix": "10.48.0.96/27"
-          },
-          {
           "name": "Internet",
           "nextHopType": "VirtualAppliance",
           "nextHopIpAddress": "10.10.200.36",

--- a/templates/vars/vnet/cftsbox-intsvc.json
+++ b/templates/vars/vnet/cftsbox-intsvc.json
@@ -46,6 +46,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.96/27"
+    },
+    "paloaltoIPNextHop": {
+      "value": "10.10.200.36"
     }
   }
 }

--- a/templates/vars/vnet/cftsbox-intsvc.json
+++ b/templates/vars/vnet/cftsbox-intsvc.json
@@ -47,11 +47,25 @@
         }
       ]
     },
-    "bastionSubnetPrefix": {
-      "value": "10.48.0.96/27"
+    "routetableName": {
+      "value": "aks-route-table"
     },
-    "paloaltoIPNextHop": {
-      "value": "10.10.200.36"
-    }
+    "routetableRoutes": {
+      "value": [
+          {
+          "name": "BastionMgmtVnet",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.10.200.36",
+          "addressPrefix": "10.48.0.96/27"
+          },
+          {
+          "name": "Internet",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.10.200.36",
+          "addressPrefix": "0.0.0.0/0"
+        }
+      ]
   }
+
+}
 }

--- a/templates/vars/vnet/cftsbox-intsvc.json
+++ b/templates/vars/vnet/cftsbox-intsvc.json
@@ -47,9 +47,6 @@
         }
       ]
     },
-    "routetableName": {
-      "value": "aks-route-table"
-    },
     "routetableRoutes": {
       "value": [
           {

--- a/templates/vars/vnet/demo.json
+++ b/templates/vars/vnet/demo.json
@@ -59,12 +59,7 @@
     },
     "routetableRoutes": {
       "value": [
-          {
-          "name": "BastionMgmtVnet",
-          "nextHopType": "VirtualAppliance",
-          "nextHopIpAddress": "10.11.72.36",
-          "addressPrefix": "10.48.0.32/27"
-          }
+
       ]
   }
   }

--- a/templates/vars/vnet/demo.json
+++ b/templates/vars/vnet/demo.json
@@ -52,9 +52,6 @@
         }
       ]
     },
-    "routetableName": {
-      "value": "aks-route-table"
-    },
     "routetableRoutes": {
       "value": [
           {

--- a/templates/vars/vnet/demo.json
+++ b/templates/vars/vnet/demo.json
@@ -62,13 +62,7 @@
           "nextHopType": "VirtualAppliance",
           "nextHopIpAddress": "10.11.72.36",
           "addressPrefix": "10.48.0.32/27"
-          },
-          {
-          "name": "Internet",
-          "nextHopType": "VirtualAppliance",
-          "nextHopIpAddress": "10.11.72.36",
-          "addressPrefix": "0.0.0.0/0"
-        }
+          }
       ]
   }
   }

--- a/templates/vars/vnet/demo.json
+++ b/templates/vars/vnet/demo.json
@@ -51,6 +51,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.32/27"
+    },
+    "paloaltoIPNextHop": {
+      "value": "10.11.72.36"
     }
   }
 }

--- a/templates/vars/vnet/demo.json
+++ b/templates/vars/vnet/demo.json
@@ -52,11 +52,24 @@
         }
       ]
     },
-    "bastionSubnetPrefix": {
-      "value": "10.48.0.32/27"
+    "routetableName": {
+      "value": "aks-route-table"
     },
-    "paloaltoIPNextHop": {
-      "value": "10.11.72.36"
-    }
+    "routetableRoutes": {
+      "value": [
+          {
+          "name": "BastionMgmtVnet",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.11.72.36",
+          "addressPrefix": "10.48.0.32/27"
+          },
+          {
+          "name": "Internet",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.11.72.36",
+          "addressPrefix": "0.0.0.0/0"
+        }
+      ]
+  }
   }
 }

--- a/templates/vars/vnet/ithc.json
+++ b/templates/vars/vnet/ithc.json
@@ -60,12 +60,6 @@
     "routetableRoutes": {
       "value": [
           {
-            "name": "BastionMgmtVnet",
-            "nextHopType": "VirtualAppliance",
-            "nextHopIpAddress": "10.11.72.36",
-            "addressPrefix": "10.48.0.0/27"
-          },
-          {
             "name": "Internet",
             "nextHopType": "VirtualAppliance",
             "nextHopIpAddress": "10.11.72.36",

--- a/templates/vars/vnet/ithc.json
+++ b/templates/vars/vnet/ithc.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "hubVnetId": {
-      "value": "/subscriptions/fb084706-583f-4c9a-bdab-949aac66ba5c/resourceGroups/hmcts-hub-nonprodi/providers/Microsoft.Network/virtualNetworks/hmcts-hub-nonprodi"
+      "value": ""
     },
     "aksVnetDnsServers": {
       "value": []

--- a/templates/vars/vnet/ithc.json
+++ b/templates/vars/vnet/ithc.json
@@ -52,11 +52,30 @@
         }
       ]
     },
-    "bastionSubnetPrefix": {
-      "value": "10.48.0.0/27"
+    "routetableName": {
+      "value": "aks-route-table"
     },
-    "paloaltoIPNextHop": {
-      "value": "10.11.8.36"
-    }
+    "routetableRoutes": {
+      "value": [
+          {
+          "name": "AKSITHCtoHUBPalo",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.11.72.36",
+          "addressPrefix": "10.0.0.0.0/8"
+          },
+          {
+            "name": "BastionMgmtVnet",
+            "nextHopType": "VirtualAppliance",
+            "nextHopIpAddress": "10.11.72.36",
+            "addressPrefix": "10.48.0.0/27"
+          },
+          {
+            "name": "Internet",
+            "nextHopType": "VirtualAppliance",
+            "nextHopIpAddress": "10.11.72.36",
+            "addressPrefix": "0.0.0.0/0"
+          }
+      ]
   }
-} 
+  }
+}

--- a/templates/vars/vnet/ithc.json
+++ b/templates/vars/vnet/ithc.json
@@ -61,7 +61,7 @@
           "name": "AKSITHCtoHUBPalo",
           "nextHopType": "VirtualAppliance",
           "nextHopIpAddress": "10.11.72.36",
-          "addressPrefix": "10.0.0.0.0/8"
+          "addressPrefix": "10.0.0.0/8"
           },
           {
             "name": "BastionMgmtVnet",

--- a/templates/vars/vnet/ithc.json
+++ b/templates/vars/vnet/ithc.json
@@ -60,12 +60,6 @@
     "routetableRoutes": {
       "value": [
           {
-          "name": "AKSITHCtoHUBPalo",
-          "nextHopType": "VirtualAppliance",
-          "nextHopIpAddress": "10.11.72.36",
-          "addressPrefix": "10.0.0.0/8"
-          },
-          {
             "name": "BastionMgmtVnet",
             "nextHopType": "VirtualAppliance",
             "nextHopIpAddress": "10.11.72.36",

--- a/templates/vars/vnet/ithc.json
+++ b/templates/vars/vnet/ithc.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "hubVnetId": {
-      "value": ""
+      "value": "/subscriptions/fb084706-583f-4c9a-bdab-949aac66ba5c/resourceGroups/hmcts-hub-nonprodi/providers/Microsoft.Network/virtualNetworks/hmcts-hub-nonprodi"
     },
     "aksVnetDnsServers": {
       "value": []

--- a/templates/vars/vnet/ithc.json
+++ b/templates/vars/vnet/ithc.json
@@ -51,6 +51,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.0/27"
+    },
+    "paloaltoIPNextHop": {
+      "value": "10.11.8.36"
     }
   }
-}
+} 

--- a/templates/vars/vnet/ithc.json
+++ b/templates/vars/vnet/ithc.json
@@ -53,7 +53,7 @@
       ]
     },
     "routetableName": {
-      "value": "aks-route-table"
+      "value": "aks-ithc-rt"
     },
     "routetableRoutes": {
       "value": [

--- a/templates/vars/vnet/ithc.json
+++ b/templates/vars/vnet/ithc.json
@@ -52,9 +52,6 @@
         }
       ]
     },
-    "routetableName": {
-      "value": "aks-ithc-rt"
-    },
     "routetableRoutes": {
       "value": [
           {

--- a/templates/vars/vnet/ldata.json
+++ b/templates/vars/vnet/ldata.json
@@ -46,6 +46,16 @@
           "service": "Microsoft.Storage"
         }
       ]
-    }
+    },
+    "routetableRoutes": {
+      "value": [
+          {
+            "name": "Internet",
+            "nextHopType": "VirtualAppliance",
+            "nextHopIpAddress": "10.11.72.36",
+            "addressPrefix": "0.0.0.0/0"
+          }
+      ]
+  }
   }
 }

--- a/templates/vars/vnet/perftest.json
+++ b/templates/vars/vnet/perftest.json
@@ -51,6 +51,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.32/27"
+    },
+    "paloaltoIPNextHop": {
+      "value": "10.11.72.36"
     }
   }
-}
+} 

--- a/templates/vars/vnet/perftest.json
+++ b/templates/vars/vnet/perftest.json
@@ -52,9 +52,6 @@
         }
       ]
     },
-    "routetableName": {
-      "value": "aks-route-table"
-    },
     "routetableRoutes": {
       "value": [
           {

--- a/templates/vars/vnet/perftest.json
+++ b/templates/vars/vnet/perftest.json
@@ -52,11 +52,21 @@
         }
       ]
     },
-    "bastionSubnetPrefix": {
-      "value": "10.48.0.32/27"
-    },
-    "paloaltoIPNextHop": {
-      "value": "10.11.72.36"
-    }
+    "routetableRoutes": {
+      "value": [
+          {
+            "name": "BastionMgmtVnet",
+            "nextHopType": "VirtualAppliance",
+            "nextHopIpAddress": "10.11.72.36",
+            "addressPrefix": "10.48.0.32/27"
+          },
+          {
+            "name": "Internet",
+            "nextHopType": "VirtualAppliance",
+            "nextHopIpAddress": "10.11.72.36",
+            "addressPrefix": "0.0.0.0/0"
+          }
+      ]
   }
-} 
+  }
+}

--- a/templates/vars/vnet/perftest.json
+++ b/templates/vars/vnet/perftest.json
@@ -52,6 +52,9 @@
         }
       ]
     },
+    "routetableName": {
+      "value": "aks-route-table"
+    },
     "routetableRoutes": {
       "value": [
           {

--- a/templates/vars/vnet/perftest.json
+++ b/templates/vars/vnet/perftest.json
@@ -60,12 +60,6 @@
     "routetableRoutes": {
       "value": [
           {
-            "name": "BastionMgmtVnet",
-            "nextHopType": "VirtualAppliance",
-            "nextHopIpAddress": "10.11.72.36",
-            "addressPrefix": "10.48.0.32/27"
-          },
-          {
             "name": "Internet",
             "nextHopType": "VirtualAppliance",
             "nextHopIpAddress": "10.11.72.36",

--- a/templates/vars/vnet/preview.json
+++ b/templates/vars/vnet/preview.json
@@ -80,12 +80,6 @@
     "routetableRoutes": {
       "value": [
           {
-            "name": "BastionMgmtVnet",
-            "nextHopType": "VirtualAppliance",
-            "nextHopIpAddress": "10.11.72.36",
-            "addressPrefix": "10.48.0.32/27"
-          },
-          {
             "name": "Internet",
             "nextHopType": "VirtualAppliance",
             "nextHopIpAddress": "10.11.72.36",

--- a/templates/vars/vnet/preview.json
+++ b/templates/vars/vnet/preview.json
@@ -72,11 +72,21 @@
         }
       ]
     },
-    "bastionSubnetPrefix": {
-      "value": "10.48.0.32/27"
-    },
-    "paloaltoIPNextHop": {
-      "value": "10.11.72.36"
-    }
+    "routetableRoutes": {
+      "value": [
+          {
+            "name": "BastionMgmtVnet",
+            "nextHopType": "VirtualAppliance",
+            "nextHopIpAddress": "10.11.72.36",
+            "addressPrefix": "10.48.0.32/27"
+          },
+          {
+            "name": "Internet",
+            "nextHopType": "VirtualAppliance",
+            "nextHopIpAddress": "10.11.72.36",
+            "addressPrefix": "0.0.0.0/0"
+          }
+      ]
+  }
   }
 }

--- a/templates/vars/vnet/preview.json
+++ b/templates/vars/vnet/preview.json
@@ -71,7 +71,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.32/27"
+    },
+    "paloaltoIPNextHop": {
+      "value": "10.11.72.36"
     }
   }
 }
-  

--- a/templates/vars/vnet/preview.json
+++ b/templates/vars/vnet/preview.json
@@ -72,6 +72,9 @@
         }
       ]
     },
+    "routetableName": {
+      "value": "aks-route-table"
+    },
     "routetableRoutes": {
       "value": [
           {

--- a/templates/vars/vnet/preview.json
+++ b/templates/vars/vnet/preview.json
@@ -72,9 +72,6 @@
         }
       ]
     },
-    "routetableName": {
-      "value": "aks-route-table"
-    },
     "routetableRoutes": {
       "value": [
           {

--- a/templates/vars/vnet/prod.json
+++ b/templates/vars/vnet/prod.json
@@ -58,9 +58,6 @@
     "paloaltoIPNextHop": {
       "value": "10.11.8.36"
     },
-    "routetableName": {
-      "value": "aks-route-table"
-    },
     "routetableRoutes": {
       "value": [
           {

--- a/templates/vars/vnet/prod.json
+++ b/templates/vars/vnet/prod.json
@@ -57,6 +57,25 @@
     },
     "paloaltoIPNextHop": {
       "value": "10.11.8.36"
-    }
+    },
+    "routetableName": {
+      "value": "aks-route-table"
+    },
+    "routetableRoutes": {
+      "value": [
+          {
+          "name": "BastionMgmtVnet",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.11.8.36",
+          "addressPrefix": "10.48.0.0/27"
+          },
+          {
+          "name": "Internet",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.11.8.36",
+          "addressPrefix": "0.0.0.0/0"
+        }
+      ]
+  }
   }
 }

--- a/templates/vars/vnet/prod.json
+++ b/templates/vars/vnet/prod.json
@@ -56,22 +56,6 @@
           "service": "Microsoft.Storage"
         }
       ]
-    },
-    "routetableRoutes": {
-      "value": [
-          {
-          "name": "BastionMgmtVnet",
-          "nextHopType": "VirtualAppliance",
-          "nextHopIpAddress": "10.11.8.36",
-          "addressPrefix": "10.48.0.0/27"
-          },
-          {
-          "name": "Internet",
-          "nextHopType": "VirtualAppliance",
-          "nextHopIpAddress": "10.11.8.36",
-          "addressPrefix": "0.0.0.0/0"
-        }
-      ]
-  }
+    }
   }
 }

--- a/templates/vars/vnet/prod.json
+++ b/templates/vars/vnet/prod.json
@@ -52,12 +52,6 @@
         }
       ]
     },
-    "bastionSubnetPrefix": {
-      "value": "10.48.0.0/27"
-    },
-    "paloaltoIPNextHop": {
-      "value": "10.11.8.36"
-    },
     "routetableRoutes": {
       "value": [
           {

--- a/templates/vars/vnet/prod.json
+++ b/templates/vars/vnet/prod.json
@@ -51,6 +51,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.0/27"
+    },
+    "paloaltoIPNextHop": {
+      "value": "10.11.8.36"
     }
   }
 }

--- a/templates/vars/vnet/sbox.json
+++ b/templates/vars/vnet/sbox.json
@@ -65,12 +65,6 @@
     "routetableRoutes": {
       "value": [
           {
-          "name": "BastionMgmtVnet",
-          "nextHopType": "VirtualAppliance",
-          "nextHopIpAddress": "10.10.200.36",
-          "addressPrefix": "10.48.0.96/27"
-          },
-          {
           "name": "Internet",
           "nextHopType": "VirtualAppliance",
           "nextHopIpAddress": "10.10.200.36",

--- a/templates/vars/vnet/sbox.json
+++ b/templates/vars/vnet/sbox.json
@@ -57,13 +57,10 @@
         }
       ]
     },
-    "bastionSubnetPrefix": {
-      "value": "10.48.0.96/27"
+    "routetableName": {
+      "value": "aks-route-table"
     },
-    "paloaltoIPNextHop": {
-      "value": "10.10.200.36"
-    },
-    "Routes": {
+    "routetableRoutes": {
       "value": [
           {
           "name": "BastionMgmtVnet",

--- a/templates/vars/vnet/sbox.json
+++ b/templates/vars/vnet/sbox.json
@@ -57,9 +57,6 @@
         }
       ]
     },
-    "routetableName": {
-      "value": "aks-route-table"
-    },
     "routetableRoutes": {
       "value": [
           {

--- a/templates/vars/vnet/sbox.json
+++ b/templates/vars/vnet/sbox.json
@@ -62,6 +62,23 @@
     },
     "paloaltoIPNextHop": {
       "value": "10.10.200.36"
-    }
+    },
+    "Routes": {
+      "value": [
+          {
+          "name": "BastionMgmtVnet",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.10.200.36",
+          "addressPrefix": "10.48.0.96/27"
+          },
+          {
+          "name": "Internet",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.10.200.36",
+          "addressPrefix": "0.0.0.0/0"
+        }
+      ]
+  }
+
   }
 }

--- a/templates/vars/vnet/sbox.json
+++ b/templates/vars/vnet/sbox.json
@@ -56,6 +56,12 @@
           "service": "Microsoft.Storage"
         }
       ]
+    },
+    "bastionSubnetPrefix": {
+      "value": "10.48.0.96/27"
+    },
+    "paloaltoIPNextHop": {
+      "value": "10.10.200.36"
     }
   }
 }


### PR DESCRIPTION
### Change description ###
- Internet traffic to Palo Alto
- Demo environment not included for now
- Swapped route table to array/copy for ease of use, in future it is planned to add additional routes for private IP routing
- Removed ITHC hub reference as it has another route assigned with different name
- Added routetableName parameter due to ITHC having a different route table assigned and private IP range

Raising PR for review, all envs applied to except for Production Jenkins & Production. Will merge once this is complete

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
