### PR TITLE
Fix min nodes on aks clusters

### DIFF
--- a/templates/vars/aks/demo.json
+++ b/templates/vars/aks/demo.json
@@ -6,10 +6,10 @@
       "value": "1.19.7"
     },
     "nodeMinCount": {
-      "value": 20
+      "value": 30
     },
     "nodeMaxCount": {
-      "value": "40"
+      "value": "50"
     },
     "enableAutoScaling": {
       "value": "true"

--- a/templates/vars/aks/ithc.json
+++ b/templates/vars/aks/ithc.json
@@ -6,10 +6,10 @@
       "value": "1.19.7"
     },
     "nodeMinCount": {
-      "value": 10
+      "value": 25
     },
     "nodeMaxCount": {
-      "value": "30"
+      "value": "40"
     },
     "enableAutoScaling": {
       "value": "true"

--- a/templates/vars/aks/perftest.json
+++ b/templates/vars/aks/perftest.json
@@ -6,10 +6,10 @@
       "value": "1.19.7"
     },
     "nodeMinCount": {
-      "value": 20
+      "value": 40
     },
     "nodeMaxCount": {
-      "value": "40"
+      "value": "50"
     },
     "enableAutoScaling": {
       "value": "true"

--- a/templates/vars/aks/prod.json
+++ b/templates/vars/aks/prod.json
@@ -9,7 +9,7 @@
       "value": "Paid"
     },
     "nodeMinCount": {
-      "value": 30
+      "value": 40
     },
     "nodeMaxCount": {
       "value": "50"

--- a/templates/vars/aks/sbox.json
+++ b/templates/vars/aks/sbox.json
@@ -6,10 +6,10 @@
       "value": "1.19.7"
     },
     "nodeMinCount": {
-      "value": 10
+      "value": 6
     },
     "nodeMaxCount": {
-      "value": "30"
+      "value": "15"
     },
     "enableAutoScaling": {
       "value": "true"


### PR DESCRIPTION
We are seeing that having less min nodes is causing many helm releases to fail triggering autoscaler during cluster rebuilds. Reviewed the mins to be closer to the average if not same.

- AAT  - Current Min - 30 , Current Avg- 32, New Min -  30 (Unchanged)
- Prod- Current Min - 30, Current Avg- 41, New Min -  40
- Demo - Current Min - 10, Current Avg- 34, New Min -  30
- ITHC - Current Min - 10, Current Avg- 28, New Min -  25
- Perftest - Current Min- 20, Current avg- 40, New Min - 38
- Sandbox - Current Min - 10, Current  Avg - 10 . Reduced it to 6.
- PTL, MGMT SBOX - they look fine and running at current min nodes.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
