### PR TITLE
Required to connect to perftest.platform.hmcts.net dns

### DIFF
--- a/templates/vars/vnet/cftptl-intsvc.json
+++ b/templates/vars/vnet/cftptl-intsvc.json
@@ -148,6 +148,12 @@
           "nextHopType": "VirtualAppliance",
           "nextHopIpAddress": "10.11.72.36",
           "addressPrefix": "10.145.0.0/18"
+        },
+        {
+          "name": "cftperftest",
+          "nextHopType": "VirtualAppliance",
+          "nextHopIpAddress": "10.11.72.36",
+          "addressPrefix": "10.48.64.0/18"
         }
       ]
   }


### PR DESCRIPTION
### Change description ###
Required to connect to perftest.platform.hmcts.net dns

Currently it is routing via Production Palo, needs to route to non-prod palo to where cft-perftest is peered to.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
