### PR TITLE
DTSPO-3990 add sandbox.platform vnet link

### DIFF
--- a/templates/vars/vnet/cftptl-intsvc.json
+++ b/templates/vars/vnet/cftptl-intsvc.json
@@ -119,6 +119,11 @@
           "name": "dev.platform.hmcts.net",
           "subscriptionId": "1baf5470-1c3e-40d3-a6f7-74bfbce4b348",
           "resourceGroup": "core-infra-intsvc-rg"
+        },
+        {
+          "name": "sandbox.platform.hmcts.net",
+          "subscriptionId": "1baf5470-1c3e-40d3-a6f7-74bfbce4b348",
+          "resourceGroup": "core-infra-intsvc-rg"
         }
       ]
     },


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-3990

### Change description ###

Add vnet link to sandbox.platform.hmcts.net private DNS zone so ADO agents can resolve netbox DNS record

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
