### PR TITLE
ubuntu version changed from 16.04 to latest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ variables:
   serviceConnection: azurerm-nonprod
   keyvaultName: infra-vault-nonprod
   terraformVersion: 0.12.8
-  agentPool: 'Ubuntu-16.04'
+  agentPool: 'ubuntu-latest'
 
 stages:
   - stage: CI


### PR DESCRIPTION
JIRA link: [DTSPO-4322](https://tools.hmcts.net/jira/browse/DTSPO-4322)

Ubuntu 16.04 LTS environment is deprecated and will be removed on September 20, 2021. 
Ubuntu version upgraded from 16.04 to latest

**Does this PR introduce a breaking change?** (check one with "x")
[  ] Yes
[X] No